### PR TITLE
fix for reloading bank after setting to default state

### DIFF
--- a/Source/State/StateManager.cpp
+++ b/Source/State/StateManager.cpp
@@ -234,7 +234,8 @@ bool StateManager::loadFromMemoryBlock(juce::MemoryBlock &mb)
             return false;
 
         setStateInformation(cset->chunk, fxbSwap(cset->chunkSize));
-        audioProcessor->setCurrentProgram(0); // Set to first preset position
+        const int currentProg = audioProcessor->getCurrentProgram();
+        audioProcessor->setCurrentProgram(currentProg, true);
     }
     else if (compareMagic(set->fxMagic, "FPCh"))
     {


### PR DESCRIPTION
When loading a bank after a reset to default state, parameters weren't being properly
applied until the program was manually reselected unless at index 0. 

Fixed with this commit!