### PR TITLE
Use basic-blocks ParamMetaData for string math etc..

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -147,6 +147,11 @@ target_link_libraries(OB-Xf PRIVATE
     mts-client
 
     obxf_version_information
+
+    simde
+    fmt
+    sst-cpputils
+    sst-basic-blocks
 )
 
 target_compile_definitions(OB-Xf PRIVATE JUCE_VST3_CAN_REPLACE_VST2=0 OBXF_VERSION_STR="${PROJECT_VERSION}")

--- a/cmake/get_dependencies.cmake
+++ b/cmake/get_dependencies.cmake
@@ -7,6 +7,51 @@
     )
     FetchContent_MakeAvailable(JUCE)
 
+
+    FetchContent_Declare(
+            fmt
+            GIT_REPOSITORY https://github.com/fmtlib/fmt.git
+            GIT_TAG 10.2.0
+    )
+
+    FetchContent_MakeAvailable(fmt)
+
+
+    FetchContent_Declare(
+            simde
+            GIT_REPOSITORY https://github.com/simd-everywhere/simde
+            GIT_TAG v0.8.2
+    )
+
+    FetchContent_MakeAvailable(simde)
+    add_library(simde INTERFACE)
+    target_include_directories(simde INTERFACE ${simde_SOURCE_DIR})
+
+
+    FetchContent_Declare(
+            sstcpp
+            GIT_REPOSITORY https://github.com/surge-synthesizer/sst-cpputils
+            GIT_TAG main
+    )
+
+    FetchContent_MakeAvailable(sstcpp)
+
+    FetchContent_Declare(
+            sstbb
+            GIT_REPOSITORY https://github.com/surge-synthesizer/sst-basic-blocks
+            GIT_TAG main
+    )
+
+    FetchContent_MakeAvailable(sstbb)
+
+    FetchContent_Declare(
+            sstbb
+            GIT_REPOSITORY https://github.com/surge-synthesizer/sst-basic-blocks
+            GIT_TAG main
+    )
+
+    FetchContent_MakeAvailable(sstbb)
+
     FetchContent_Declare(
             sstplugininfra
             GIT_REPOSITORY https://github.com/surge-synthesizer/sst-plugininfra

--- a/src/engine/VoiceQueue.h
+++ b/src/engine/VoiceQueue.h
@@ -24,6 +24,7 @@
 #define OBXF_SRC_ENGINE_VOICEQUEUE_H
 
 #include "ObxfVoice.h"
+#include <cassert>
 
 class VoiceQueue
 {
@@ -41,6 +42,7 @@ class VoiceQueue
 
     VoiceQueue(int voiceCount, ObxfVoice *voicesReference)
     {
+        assert(voiceCount <= MAX_VOICES);
         voices = voicesReference;
         idx = 0;
         total = voiceCount;
@@ -55,9 +57,16 @@ class VoiceQueue
 
     inline void reInit(int voiceCount)
     {
+        assert(voiceCount <= MAX_VOICES);
         total = voiceCount;
         idx = idx % total;
     }
+
+    ObxfVoice **begin() { return &voices; }
+    ObxfVoice **end() { return &voices + total; }
+
+    ObxfVoice * const *cbegin() const { return &voices; }
+    ObxfVoice * const *cend() const { return &voices + total; }
 };
 
 #endif // OBXF_SRC_ENGINE_VOICEQUEUE_H

--- a/src/parameter/FreeLayoutHelper.h
+++ b/src/parameter/FreeLayoutHelper.h
@@ -36,10 +36,34 @@ createParameterLayout(const std::vector<ParameterInfo> &infos)
 
     for (const auto &info : infos)
     {
-        auto range = juce::NormalisableRange<float>{info.min, info.max, info.inc, info.skw};
+        // Fix that inc and skew
+        juce::NormalisableRange<float> range;
 
-        auto stringFromValue = [id = info.ID](const float value, int /*maxStringLength*/) {
+        if (info.meta.has_value())
+        {
+            range = juce::NormalisableRange<float>{
+                info.meta->minVal, info.meta->maxVal,
+                (info.meta->type == sst::basic_blocks::params::ParamMetaData::Type::FLOAT) ? 0.00001f
+                                                                                           : 1.f,
+                1.f};
+            DBG("Range is set by meta");
+        }
+        else
+        {
+            range = juce::NormalisableRange<float>{info.min, info.max, info.inc, info.skw};
+        }
+
+        auto stringFromValue = [id = info.ID, meta = info.meta](
+                                   const float value, int /*maxStringLength*/) -> juce::String {
             juce::String result;
+            if (meta.has_value())
+            {
+                auto res = meta->valueToString(value);
+                if (res.has_value())
+                    return *res;
+                else
+                    return "-error--";
+            }
 
             if (id == ID::VibratoRate)
             {
@@ -136,11 +160,37 @@ createParameterLayout(const std::vector<ParameterInfo> &infos)
             return result;
         };
 
-        auto parameter = std::make_unique<juce::AudioParameterFloat>(
-            juce::ParameterID{info.ID, 1}, info.name, range, info.def, info.unit,
-            juce::AudioProcessorParameter::genericParameter, stringFromValue);
 
-        params.push_back(std::move(parameter));
+        if (info.meta.has_value())
+        {
+
+            auto valueFromString = [id = info.ID, meta = info.meta](
+                                       const juce::String &s) -> float {
+                juce::String result;
+                if (meta.has_value())
+                {
+                    std::string em;
+                    auto res = meta->valueFromString(s.toStdString(), em);
+                    if (res.has_value())
+                        return *res;
+                    else
+                        return 0.f;
+                }
+                return 0;
+            };
+
+            auto parameter = std::make_unique<juce::AudioParameterFloat>(
+                juce::ParameterID{info.ID, 1}, info.meta->name, range, info.meta->defaultVal, "",
+                juce::AudioProcessorParameter::genericParameter, stringFromValue, valueFromString);
+            params.push_back(std::move(parameter));
+        }
+        else
+        {
+            auto parameter = std::make_unique<juce::AudioParameterFloat>(
+                juce::ParameterID{info.ID, 1}, info.name, range, info.def, info.unit,
+                juce::AudioProcessorParameter::genericParameter, stringFromValue);
+            params.push_back(std::move(parameter));
+        }
     }
 
     return {params.begin(), params.end()};

--- a/src/parameter/ParameterAdaptor.h
+++ b/src/parameter/ParameterAdaptor.h
@@ -34,6 +34,8 @@
 
 using namespace SynthParam;
 
+using pmd = sst::basic_blocks::params::ParamMetaData;
+
 static const std::vector<ParameterInfo> Parameters{
     {ID::SelfOscPush, Name::SelfOscPush, Units::None, Defaults::SelfOscPush, Ranges::DefaultMin,
      Ranges::DefaultMax, Ranges::DefaultIncrement, Ranges::DefaultSkew},
@@ -65,8 +67,12 @@ static const std::vector<ParameterInfo> Parameters{
      Ranges::DefaultMax, Ranges::DefaultIncrement, Ranges::DefaultSkew},
     {ID::LegatoMode, Name::LegatoMode, Units::None, Defaults::LegatoMode, Ranges::DefaultMin,
      Ranges::DefaultMax, Ranges::DefaultIncrement, Ranges::DefaultSkew},
-    {ID::EnvelopeToPitch, Name::EnvelopeToPitch, Units::Semitones, Defaults::EnvelopeToPitch,
-     Ranges::DefaultMin, Ranges::DefaultMax, Ranges::Continuous, Ranges::DefaultSkew},
+
+
+    // This is the only we we have test ported
+    {ID::EnvelopeToPitch, pmd().asFloat().withName(Name::EnvelopeToPitch.toStdString()).withDefault(0.f).withRange(0.f, 1.f).withLinearScaleFormatting("semitones", 36).withDecimalPlaces(2)},
+     // end
+
     {ID::EnvelopeToPitchInv, Name::EnvelopeToPitchInv, Units::None, Defaults::EnvelopeToPitchInv,
      Ranges::DefaultMin, Ranges::DefaultMax, Ranges::DefaultIncrement, Ranges::DefaultSkew},
     {ID::VoiceCount, Name::VoiceCount, Units::None, Defaults::VoiceCount, Ranges::DefaultMin,

--- a/src/parameter/ParameterInfo.h
+++ b/src/parameter/ParameterInfo.h
@@ -23,8 +23,11 @@
 #ifndef OBXF_SRC_PARAMETER_PARAMETERINFO_H
 #define OBXF_SRC_PARAMETER_PARAMETERINFO_H
 
+#include <optional>
 #include <juce_audio_basics/juce_audio_basics.h>
+#include <sst/basic-blocks/params/ParamMetadata.h>
 
+// Original Code
 struct ParameterInfo
 {
     enum Type : uint32_t
@@ -33,6 +36,11 @@ struct ParameterInfo
         Choice,
         Bool
     };
+
+    using pmd = sst::basic_blocks::params::ParamMetaData;
+    ParameterInfo(const juce::String &_ID, const pmd &_meta) : ID(_ID), meta(_meta)
+    {
+    }
 
     // Float ctor
     ParameterInfo(const juce::String &_ID, const juce::String &_name, const juce::String &_unit,
@@ -88,19 +96,9 @@ struct ParameterInfo
         jassert(skw > 0.f);
     }
 
-    // Copy ctor
-    ParameterInfo(const ParameterInfo &other)
-        : ID{other.ID}, name{other.name}, unit{other.unit}, steps{other.steps}, type{other.type},
-          def{other.def}, min{other.min}, max{other.max}, inc{other.inc}, skw{other.skw}
-    {
-    }
-
-    // No move ctor
-    ParameterInfo(ParameterInfo &&other)
-        : ID{other.ID}, name{other.name}, unit{other.unit}, steps{other.steps}, type{other.type},
-          def{other.def}, min{other.min}, max{other.max}, inc{other.inc}, skw{other.skw}
-    {
-    }
+    // Copy and move ctor
+    ParameterInfo(const ParameterInfo &other) = default;
+    ParameterInfo(ParameterInfo &&other) = default;
 
     // No default ctor
     ParameterInfo() = delete;
@@ -111,18 +109,20 @@ struct ParameterInfo
 
     ~ParameterInfo() noexcept = default;
 
-    const juce::String ID;
-    const juce::String name;
-    const juce::String unit;
-    const juce::StringArray steps;
+    const juce::String ID{};
+    const std::optional<pmd> meta{std::nullopt};
 
-    const Type type;
+    const juce::String name{};
+    const juce::String unit{};
+    const juce::StringArray steps{};
 
-    const float def;
-    const float min;
-    const float max;
-    const float inc;
-    const float skw;
+    const Type type{Float};
+
+    const float def{0};
+    const float min{0};
+    const float max{1};
+    const float inc{0};
+    const float skw{0};
 };
 
 #endif // OBXF_SRC_PARAMETER_PARAMETERINFO_H


### PR DESCRIPTION
This change allows us to use sst-basic-blocks ParamMetadata class for string conversions, unit specifications, etc... and does so for exactly one parameter, EnvelopeToPitch. But it plumbs it through.

Ideally the code which isn't metadata based would go away when we have all of ParameterAdapter.h Parameters data structure proted