### PR TITLE
Add an ObxfParameterFloat which contains a metadata

### DIFF
--- a/src/gui/Knob.h
+++ b/src/gui/Knob.h
@@ -82,16 +82,11 @@ class Knob final : public juce::Slider, public ScalableComponent, public juce::A
 
         std::optional<sst::basic_blocks::params::ParamMetaData> getMetadata()
         {
-            // This kinda sucks
-            auto id = knob->parameter->getParameterID();
-            for (const auto &pinf : Parameters)
-            {
-                if (pinf.ID == id)
-                {
-                    return pinf.meta;
-                }
-            }
-            return std::nullopt;
+            auto op = dynamic_cast<ObxfParameterFloat *>(knob->parameter);
+            if (op)
+                return op->meta;
+            else
+                return std::nullopt;
         }
         void visibilityChanged() override
         {

--- a/src/parameter/FreeLayoutHelper.h
+++ b/src/parameter/FreeLayoutHelper.h
@@ -54,17 +54,9 @@ createParameterLayout(const std::vector<ParameterInfo> &infos)
             range = juce::NormalisableRange<float>{info.min, info.max, info.inc, info.skw};
         }
 
-        auto stringFromValue = [id = info.ID, meta = info.meta](
-                                   const float value, int /*maxStringLength*/) -> juce::String {
+        auto stringFromValue = [id = info.ID](const float value,
+                                              int /*maxStringLength*/) -> juce::String {
             juce::String result;
-            if (meta.has_value())
-            {
-                auto res = meta->valueToString(value);
-                if (res.has_value())
-                    return *res;
-                else
-                    return "-error--";
-            }
 
             if (id == ID::VibratoRate)
             {
@@ -164,24 +156,8 @@ createParameterLayout(const std::vector<ParameterInfo> &infos)
         if (info.meta.has_value())
         {
 
-            auto valueFromString = [id = info.ID,
-                                    meta = info.meta](const juce::String &s) -> float {
-                juce::String result;
-                if (meta.has_value())
-                {
-                    std::string em;
-                    auto res = meta->valueFromString(s.toStdString(), em);
-                    if (res.has_value())
-                        return *res;
-                    else
-                        return 0.f;
-                }
-                return 0;
-            };
-
-            auto parameter = std::make_unique<juce::AudioParameterFloat>(
-                juce::ParameterID{info.ID, 1}, info.meta->name, range, info.meta->defaultVal, "",
-                juce::AudioProcessorParameter::genericParameter, stringFromValue, valueFromString);
+            auto parameter = std::make_unique<ObxfParameterFloat>(juce::ParameterID{info.ID, 1},
+                                                                  range, *info.meta);
             params.push_back(std::move(parameter));
         }
         else

--- a/src/parameter/SynthParam.h
+++ b/src/parameter/SynthParam.h
@@ -24,6 +24,7 @@
 #define OBXF_SRC_PARAMETER_SYNTHPARAM_H
 
 #include <juce_audio_basics/juce_audio_basics.h>
+#include <sst/basic-blocks/params/ParamMetadata.h>
 
 namespace SynthParam
 {
@@ -310,5 +311,43 @@ static constexpr float FilterSustain{1.0f};
 static constexpr float FilterRelease{0.2f};
 } // namespace Defaults
 } // namespace SynthParam
+
+struct ObxfParameterFloat : juce::AudioParameterFloat
+{
+    ObxfParameterFloat(const juce::ParameterID &parameterID,
+                       juce::NormalisableRange<float> normalisableRange,
+                       const sst::basic_blocks::params::ParamMetaData &md)
+        : juce::AudioParameterFloat(
+              parameterID, md.name, normalisableRange, md.defaultVal,
+              juce::AudioParameterFloatAttributes()
+                  .withLabel(md.unit)
+                  .withCategory(juce::AudioProcessorParameter::genericParameter)
+                  .withStringFromValueFunction(
+                      [this](auto v, auto s) { return this->stringFromValue(v, s); })
+                  .withValueFromStringFunction(
+                      [this](auto v) { return this->valueFromString(v); })),
+          meta(md)
+    {
+    }
+    sst::basic_blocks::params::ParamMetaData meta;
+
+    juce::String stringFromValue(float value, int)
+    {
+        auto res = meta.valueToString(value);
+        if (res.has_value())
+            return *res;
+        else
+            return "-error--";
+    }
+    float valueFromString(const juce::String &s)
+    {
+        std::string em;
+        auto res = meta.valueFromString(s.toStdString(), em);
+        if (res.has_value())
+            return *res;
+        else
+            return 0.f;
+    }
+};
 
 #endif // OBXF_SRC_PARAMETER_SYNTHPARAM_H


### PR DESCRIPTION
Basically make an AudioParameterFloat subclass containing an sst-basic-blocks ParamMetadata and then start adjusting code.

Addresses #113