### PR TITLE
Make attack time basically match the display

### DIFF
--- a/scripts/attacksim.py
+++ b/scripts/attacksim.py
@@ -1,0 +1,30 @@
+
+import math;
+
+def atsim(atk):
+    Value = 0.
+    coeff = 0.;
+    sr = 48000;
+
+    ts = 0.001
+    te = 1.0  # set this to 1 for no acceleration
+    twhile = 0.1 # set this to ts for exact calculation
+    top = (math.log(ts) - math.log(te))
+    bot = sr * atk / 1000;
+    coef = top / bot;
+
+    Value = 0.
+
+    idx = 0
+    while (Value - 1 < -twhile):
+        Value = Value - (1-Value)*coef
+        idx = idx + 1
+
+    print(atk, "ms -> ", idx / sr * 1000, "ms; ratio", idx / sr * 1000 / atk, " or ", math.log(twhile)/math.log(ts))
+
+atsim(6)
+atsim(70)
+atsim(1000)
+atsim(4000)
+atsim(8000)
+atsim(60000)


### PR DESCRIPTION
The attack time, with its 0.9 peak and coeffients set to a 1.0 overshoot. didn't match the display time. This fixes it by adjusting the attack time in the coefficient appropriately.

And also stable under modulation

Addresses #116

Still need to check release and decay same way
And still need to move to basic blocks metadat