### PR TITLE
Param Metadata Wrapup

### DIFF
--- a/src/parameter/FreeLayoutHelper.h
+++ b/src/parameter/FreeLayoutHelper.h
@@ -32,23 +32,20 @@ createParameterLayout(const std::vector<ParameterInfo> &infos)
 {
     std::vector<std::unique_ptr<juce::RangedAudioParameter>> params;
 
+    size_t index{0};
     for (const auto &info : infos)
     {
         // Fix that inc and skew
         juce::NormalisableRange<float> range;
 
-        if (info.meta.has_value())
-        {
-            range = juce::NormalisableRange<float>{
-                info.meta->minVal, info.meta->maxVal,
-                (info.meta->type == sst::basic_blocks::params::ParamMetaData::Type::FLOAT)
-                    ? 0.00001f
-                    : 1.f,
-                1.f};
-        }
+        range = juce::NormalisableRange<float>{
+            info.meta.minVal, info.meta.maxVal,
+            (info.meta.type == sst::basic_blocks::params::ParamMetaData::Type::FLOAT) ? 0.00001f
+                                                                                      : 1.f,
+            1.f};
 
-        auto parameter =
-            std::make_unique<ObxfParameterFloat>(juce::ParameterID{info.ID, 1}, range, *info.meta);
+        auto parameter = std::make_unique<ObxfParameterFloat>(juce::ParameterID{info.ID, 1}, range,
+                                                              index++, info.meta);
         params.push_back(std::move(parameter));
     }
 

--- a/src/parameter/ParameterAdaptor.h
+++ b/src/parameter/ParameterAdaptor.h
@@ -166,9 +166,7 @@ static const std::vector<ParameterInfo> ParameterList{
     {ID::PwOsc2Ofs, pmd().asFloat().withName(Name::PwOsc2Ofs.toStdString()).withDefault(0.f).withRange(0.f, 1.f).asPercent().withDecimalPlaces(2)},
     {ID::EnvelopeToPWInv, pmd().asBool().withName(Name::EnvelopeToPWInv.toStdString())},
 
-    //TODO:
-    {ID::EconomyMode, Name::EconomyMode, Units::None, Defaults::EconomyMode, Ranges::DefaultMin,
-     Ranges::DefaultMax, Ranges::DefaultIncrement, Ranges::DefaultSkew},
+    {ID::EconomyMode, pmd().asBool().withName(Name::EconomyMode.toStdString()).withDefault(Defaults::EconomyMode) },
     // <-- OTHER END -->
 };
 // clang-format on

--- a/src/parameter/ParameterInfo.h
+++ b/src/parameter/ParameterInfo.h
@@ -23,7 +23,6 @@
 #ifndef OBXF_SRC_PARAMETER_PARAMETERINFO_H
 #define OBXF_SRC_PARAMETER_PARAMETERINFO_H
 
-#include <optional>
 #include <juce_audio_basics/juce_audio_basics.h>
 #include <sst/basic-blocks/params/ParamMetadata.h>
 
@@ -40,60 +39,6 @@ struct ParameterInfo
     using pmd = sst::basic_blocks::params::ParamMetaData;
     ParameterInfo(const juce::String &_ID, const pmd &_meta) : ID(_ID), meta(_meta) {}
 
-    // Float ctor
-    ParameterInfo(const juce::String &_ID, const juce::String &_name, const juce::String &_unit,
-                  float _def, float _min, float _max, float _inc, float _skw)
-        : ID{_ID}, name{_name}, unit{_unit}, steps{}, type{Float}, def{_def}, min{_min}, max{_max},
-          inc{_inc}, skw{_skw}
-    {
-        jassert(ID.isNotEmpty());
-        jassert(min < max);
-        // use std::cout to debug
-        // if (!(_def <= _max && _def >= _min)) {
-        //     std::cout << "Parameter assertion failure for: " << _ID << std::endl;
-        //     std::cout << "def: " << _def << ", min: " << _min << ", max: " << _max << std::endl;
-        // }
-
-        jassert(def <= max && def >= min);
-        jassert(inc >= 0.f);
-        jassert(skw > 0.f);
-    }
-
-    // Choice ctor
-    ParameterInfo(const juce::String &_ID, const juce::String &_name,
-                  const juce::StringArray &_steps, unsigned int _def)
-        : ID{_ID}, name{_name}, unit{}, steps{_steps}, type{Choice}, def{static_cast<float>(_def)},
-          min{0.f}, max{static_cast<float>(_steps.size() - 1)}, inc{1.f}, skw{1.f}
-    {
-        jassert(ID.isNotEmpty());
-        jassert(min < max);
-        jassert(def <= max && def >= min);
-        jassert(steps.size() == 0 || steps.size() == static_cast<int>(max + 1.f));
-    }
-
-    // Bool ctor
-    ParameterInfo(const juce::String &_ID, const juce::String &_name,
-                  const juce::String &offStepName, const juce::String &onStepName, bool _def)
-        : ID{_ID}, name{_name}, unit{}, steps{offStepName, onStepName}, type{Bool},
-          def{static_cast<float>(_def)}, min{0.f}, max{1.f}, inc{1.f}, skw{1.f}
-    {
-        jassert(ID.isNotEmpty());
-    }
-
-    // Generic ctor
-    ParameterInfo(const juce::String &_ID, const juce::String &_name, const juce::String &_unit,
-                  const juce::String &_steps, Type _type, float _def, float _min, float _max,
-                  float _inc, float _skw)
-        : ID{_ID}, name{_name}, unit{_unit}, steps{_steps}, type{_type}, def{_def}, min{_min},
-          max{_max}, inc{_inc}, skw{_skw}
-    {
-        jassert(ID.isNotEmpty());
-        jassert(min < max);
-        jassert(def <= max && def >= min);
-        jassert(inc >= 0.f);
-        jassert(skw > 0.f);
-    }
-
     // Copy and move ctor
     ParameterInfo(const ParameterInfo &other) = default;
     ParameterInfo(ParameterInfo &&other) = default;
@@ -108,19 +53,7 @@ struct ParameterInfo
     ~ParameterInfo() noexcept = default;
 
     const juce::String ID{};
-    const std::optional<pmd> meta{std::nullopt};
-
-    const juce::String name{};
-    const juce::String unit{};
-    const juce::StringArray steps{};
-
-    const Type type{Float};
-
-    const float def{0};
-    const float min{0};
-    const float max{1};
-    const float inc{0};
-    const float skw{0};
+    const pmd meta{};
 };
 
 #endif // OBXF_SRC_PARAMETER_PARAMETERINFO_H

--- a/src/parameter/SynthParam.h
+++ b/src/parameter/SynthParam.h
@@ -324,7 +324,7 @@ static constexpr float FilterRelease{0.2f};
 struct ObxfParameterFloat : juce::AudioParameterFloat
 {
     ObxfParameterFloat(const juce::ParameterID &parameterID,
-                       juce::NormalisableRange<float> normalisableRange,
+                       juce::NormalisableRange<float> normalisableRange, size_t paramIndexIn,
                        const sst::basic_blocks::params::ParamMetaData &md)
         : juce::AudioParameterFloat(
               parameterID, md.name, normalisableRange, md.defaultVal,
@@ -335,10 +335,11 @@ struct ObxfParameterFloat : juce::AudioParameterFloat
                       [this](auto v, auto s) { return this->stringFromValue(v, s); })
                   .withValueFromStringFunction(
                       [this](auto v) { return this->valueFromString(v); })),
-          meta(md)
+          meta(md), paramIndex(paramIndexIn)
     {
     }
     sst::basic_blocks::params::ParamMetaData meta;
+    size_t paramIndex{0};
 
     juce::String stringFromValue(float value, int)
     {


### PR DESCRIPTION
1. Do ecomode
2. Modify ParameterInfo so that the meta is no longer optional
3. Remove other ParameterInfo constructors and members
4. Put the parameter index into the ObxfParameterFLoat