### PR TITLE
fix: default state no longer restored when changing skin

### DIFF
--- a/src/PluginEditor.cpp
+++ b/src/PluginEditor.cpp
@@ -185,13 +185,13 @@ void ObxfAudioProcessorEditor::loadSkin(ObxfAudioProcessor &ownerFilter)
     noThemesAvailable = false;
 
     std::map<juce::String, float> parameterValues;
-    for (auto& [paramId, component] : mappingComps)
+    for (auto &[paramId, component] : mappingComps)
     {
-        if (const auto* knob = dynamic_cast<Knob*>(component))
+        if (const auto *knob = dynamic_cast<Knob *>(component))
         {
             parameterValues[paramId] = static_cast<float>(knob->getValue());
         }
-        else if (const auto* button = dynamic_cast<ToggleButton*>(component))
+        else if (const auto *button = dynamic_cast<ToggleButton *>(component))
         {
             parameterValues[paramId] = button->getToggleState() ? 1.0f : 0.0f;
         }
@@ -939,17 +939,17 @@ void ObxfAudioProcessorEditor::loadSkin(ObxfAudioProcessor &ownerFilter)
 
     createMenu();
 
-    for (auto& [paramId, paramValue] : parameterValues)
+    for (auto &[paramId, paramValue] : parameterValues)
     {
         if (mappingComps.find(paramId) != mappingComps.end())
         {
-            Component* comp = mappingComps[paramId];
+            Component *comp = mappingComps[paramId];
 
-            if (auto* knob = dynamic_cast<Knob*>(comp))
+            if (auto *knob = dynamic_cast<Knob *>(comp))
             {
                 knob->setValue(paramValue, juce::dontSendNotification);
             }
-            else if (auto* button = dynamic_cast<ToggleButton*>(comp))
+            else if (auto *button = dynamic_cast<ToggleButton *>(comp))
             {
                 button->setToggleState(paramValue > 0.5f, juce::dontSendNotification);
             }


### PR DESCRIPTION
- store values in a map and restore after clearing attachments

fixes #144
