### PR TITLE
fix clear button no longer resets all parameter values

### DIFF
--- a/src/PluginEditor.cpp
+++ b/src/PluginEditor.cpp
@@ -1659,10 +1659,8 @@ void ObxfAudioProcessorEditor::buttonClicked(juce::Button *b)
     {
         if (midiUnlearnButton->getToggleState())
         {
-            countTimerForLed = 0;
             processor.getMidiMap().reset();
             processor.getMidiMap().set_default();
-            processor.sendChangeMessage();
         }
     }
 }


### PR DESCRIPTION
remove the call to sendChangeMessage()