### PR TITLE
Cleanup some param access helpers a bit

### DIFF
--- a/src/PluginProcessor.cpp
+++ b/src/PluginProcessor.cpp
@@ -333,20 +333,16 @@ void ObxfAudioProcessor::initializeCallbacks()
 void ObxfAudioProcessor::randomizeAllPans()
 {
     std::uniform_real_distribution dist(-1.0f, 1.0f);
-    for (auto *param : getParameters())
+    for (auto *param : ObxfParams(*this))
     {
-        if (param && param->getName(20).toLowerCase().contains("pan"))
+        if (param && param->meta.hasFeature(ObxfParamFeatures::IS_PAN))
         {
             auto res = dist(panRng);
             // This smudges us a bit towards center pref
             res = res * res * res;
             res = (res + 1.0f) / 2.0f;
 
-            // Then we have to normalize
-            auto *floatParam = dynamic_cast<juce::AudioParameterFloat *>(param);
-            assert(floatParam);
-
-            const float normalized = floatParam->convertTo0to1(res);
+            const float normalized = param->convertTo0to1(res);
 
             param->beginChangeGesture();
             param->setValueNotifyingHost(normalized);
@@ -357,17 +353,14 @@ void ObxfAudioProcessor::randomizeAllPans()
 
 void ObxfAudioProcessor::resetAllPansToDefault() const
 {
-    for (auto *param : getParameters())
+    for (auto *param : ObxfParams(*this))
     {
-        if (param && param->getName(20).toLowerCase().contains("pan"))
+        if (param && param->meta.hasFeature(ObxfParamFeatures::IS_PAN))
         {
-            auto *floatParam = dynamic_cast<juce::AudioParameterFloat *>(param);
-            assert(floatParam);
-
-            const float normalized = floatParam->convertTo0to1(0.5f);
-            floatParam->beginChangeGesture();
-            floatParam->setValueNotifyingHost(normalized);
-            floatParam->endChangeGesture();
+            const float normalized = param->convertTo0to1(0.5f);
+            param->beginChangeGesture();
+            param->setValueNotifyingHost(normalized);
+            param->endChangeGesture();
         }
     }
 }

--- a/src/PluginProcessor.h
+++ b/src/PluginProcessor.h
@@ -140,6 +140,44 @@ class ObxfAudioProcessor final : public juce::AudioProcessor,
     void randomizeAllPans();
     void resetAllPansToDefault() const;
 
+    struct ObxfParams
+    {
+        const juce::Array<juce::AudioProcessorParameter *> &par;
+        ObxfParams(const juce::Array<juce::AudioProcessorParameter *> &p) : par(p) {}
+        ObxfParams(const ObxfAudioProcessor &other) : par(other.getParameters()) {}
+
+        struct iterator
+        {
+            ObxfParams &op;
+            int pos{0};
+            bool end{false};
+            iterator(ObxfParams &p, size_t pp) : op(p), pos(pp) {}
+            iterator(ObxfParams &p) : op(p), end(true) {}
+            bool operator==(const iterator &other) const
+            {
+                if (end && end == other.end)
+                    return true;
+                if (!end && !other.end && pos == other.pos)
+                    return true;
+                return false;
+            }
+            bool operator!=(const iterator &other) const { return !(*this == other); }
+            void operator++()
+            {
+                pos++;
+                if (pos >= op.par.size())
+                    end = true;
+            }
+            ObxfParameterFloat *operator*()
+            {
+                return static_cast<ObxfParameterFloat *>(op.par[pos]);
+            }
+        };
+
+        iterator begin() { return iterator(*this, 0); }
+        iterator end() { return iterator(*this); }
+    };
+
   private:
     juce::MidiKeyboardState keyboardState;
     std::atomic<bool> isHostAutomatedChange{};

--- a/src/parameter/ParameterAdaptor.h
+++ b/src/parameter/ParameterAdaptor.h
@@ -36,6 +36,13 @@ using namespace SynthParam;
 
 using pmd = sst::basic_blocks::params::ParamMetaData;
 
+enum ObxfParamFeatures : uint64_t
+{
+    IS_PAN = (uint64_t)pmd::Features::USER_FEATURE_0,
+    // F2 = IS_PAN << 1
+    // F3 = IS_PAN << 2
+};
+
 inline pmd customPan()
 {
     // This basically sets up the pan knobs showing stuff like 37 L, 92 R and Center
@@ -45,6 +52,7 @@ inline pmd customPan()
         .withLinearScaleFormatting("R", 100)
         .withDisplayRescalingBelow(0, -1, "L")
         .withDefault(0.f)
+        .withFeature((uint64_t)IS_PAN)
         .withDecimalPlaces(0)
         .withCustomDefaultDisplay("Center");
 }


### PR DESCRIPTION
1. Add ObxfParams(*this) container which allows typed iteration over the params
2. Add a user feature state to PMD which
3. I use to tag pan params so
4. We don't need string math any more in randomize pan