### PR TITLE
Make melatonin insepctor a unique_ptr

### DIFF
--- a/src/PluginEditor.cpp
+++ b/src/PluginEditor.cpp
@@ -111,6 +111,10 @@ ObxfAudioProcessorEditor::ObxfAudioProcessorEditor(ObxfAudioProcessor &p)
 
     idleTimer = std::make_unique<IdleTimer>(this);
     idleTimer->startTimer(1000 / 30);
+
+#if defined(DEBUG) || defined(_DEBUG)
+    inspector = std::make_unique<melatonin::Inspector>(*this);
+#endif
 }
 
 void ObxfAudioProcessorEditor::resized()
@@ -1107,6 +1111,10 @@ void ObxfAudioProcessorEditor::loadSkin(ObxfAudioProcessor &ownerFilter)
 
 ObxfAudioProcessorEditor::~ObxfAudioProcessorEditor()
 {
+#if defined(DEBUG) || defined(_DEBUG)
+    inspector.reset();
+#endif
+
     idleTimer->stopTimer();
     processor.removeChangeListener(this);
     setLookAndFeel(nullptr);

--- a/src/PluginEditor.h
+++ b/src/PluginEditor.h
@@ -175,7 +175,7 @@ class ObxfAudioProcessorEditor final : public juce::AudioProcessorEditor,
     ParameterManagerAdaptor &paramManager;
     std::unique_ptr<KeyCommandHandler> keyCommandHandler;
 #if defined(DEBUG) || defined(_DEBUG)
-    melatonin::Inspector inspector{*this};
+    std::unique_ptr<melatonin::Inspector> inspector{};
 #endif
     juce::Image backgroundImage;
     std::map<juce::String, Component *> mappingComps;


### PR DESCRIPTION
to avoid an occasional crash on exit with a selected item due to destruction re-ordering