### PR TITLE
fix programs having wrong values

### DIFF
--- a/src/PluginProcessor.cpp
+++ b/src/PluginProcessor.cpp
@@ -176,8 +176,8 @@ void ObxfAudioProcessor::setCurrentProgram(const int index)
             {
                 const auto &paramId = param->paramID;
                 auto it = prog->values.find(paramId);
-                const float value = (it != prog->values.end()) ?
-                    it->second.load() : param->meta.defaultVal;
+                const float value =
+                    (it != prog->values.end()) ? it->second.load() : param->meta.defaultVal;
 
                 const float normalized = param->convertTo0to1(value);
 
@@ -208,8 +208,8 @@ void ObxfAudioProcessor::setCurrentProgram(const int index, const bool updateHos
             {
                 const auto &paramId = param->paramID;
                 auto it = prog->values.find(paramId);
-                const float value = (it != prog->values.end()) ?
-                    it->second.load() : param->meta.defaultVal;
+                const float value =
+                    (it != prog->values.end()) ? it->second.load() : param->meta.defaultVal;
 
                 const float normalized = param->convertTo0to1(value);
 

--- a/src/PluginProcessor.h
+++ b/src/PluginProcessor.h
@@ -96,8 +96,6 @@ class ObxfAudioProcessor final : public juce::AudioProcessor,
 
     void setStateInformation(const void *data, int sizeInBytes) override;
 
-    void initAllParams();
-
     MidiMap &getMidiMap() { return bindings; }
 
     const Bank &getPrograms() const { return programs; }


### PR DESCRIPTION
this fixes both loading and initialising progs.

TODO:

- when loading from state parameters with values -1 to 1 increment. 
- this is a normalising issue in the state manager to fix