### PR TITLE
Add a UI State pattern

### DIFF
--- a/src/PluginProcessor.cpp
+++ b/src/PluginProcessor.cpp
@@ -103,6 +103,16 @@ void ObxfAudioProcessor::processBlock(juce::AudioBuffer<float> &buffer,
         synth.processSample(channelData1 + samplePos, channelData2 + samplePos);
         ++samplePos;
     }
+
+    if (uiState.editorAttached)
+    {
+        uiState.lastUpdate += numSamples;
+        if (uiState.lastUpdate >= uiState.updateInterval)
+        {
+            uiState.lastUpdate = 0;
+            updateUIState();
+        }
+    }
 }
 
 #ifndef JucePlugin_PreferredChannelConfigurations
@@ -365,6 +375,14 @@ void ObxfAudioProcessor::resetAllPansToDefault()
     isHostAutomatedChange = true;
     sendChangeMessage();
     updateHostDisplay();
+}
+
+void ObxfAudioProcessor::updateUIState()
+{
+    for (int i = 0; i < MAX_VOICES; ++i)
+    {
+        uiState.voiceStatusValue[i] = synth.getVoiceStatus(i);
+    }
 }
 
 //==============================================================================

--- a/src/PluginProcessor.h
+++ b/src/PluginProcessor.h
@@ -176,6 +176,21 @@ class ObxfAudioProcessor final : public juce::AudioProcessor,
         iterator end() { return iterator(*this); }
     };
 
+    struct SharedUIState
+    {
+        // Editor write Audio read
+        std::atomic<bool> editorAttached;
+
+        // Audio write editor read
+        std::array<std::atomic<float>, MAX_VOICES> voiceStatusValue;
+
+        // AUdio only
+        int32_t lastUpdate{0};
+        // 48k at 60hz is 800 samples
+        static constexpr int32_t updateInterval{500};
+    } uiState;
+    void updateUIState();
+
   private:
     juce::MidiKeyboardState keyboardState;
     std::atomic<bool> isHostAutomatedChange{};


### PR DESCRIPTION
1. Add a uiState object member of the processor which allows the processor to send information to the ui for display
2. Implement an editor attached so we only do that if the editor is open; toggle when idle starts and stops
3. Use this to move the voice state into the audio thread and audio thread is just an atomic read