### PR TITLE
Moved updating MTS status to per block

### DIFF
--- a/src/PluginProcessor.cpp
+++ b/src/PluginProcessor.cpp
@@ -91,6 +91,8 @@ void ObxfAudioProcessor::processBlock(juce::AudioBuffer<float> &buffer,
     auto it = midiMessages.begin();
     const bool hasMidiMessage = (it != midiMessages.end());
 
+    synth.getMotherboard()->tuning.updateMTSESPStatus();
+
     while (samplePos < numSamples)
     {
         if (hasMidiMessage)

--- a/src/engine/Motherboard.h
+++ b/src/engine/Motherboard.h
@@ -501,14 +501,15 @@ class Motherboard
 
     void processSample(float *sm1, float *sm2)
     {
-        tuning.updateMTSESPStatus();
         globalLFO.update();
         vibratoLFO.update();
+
         float vl = 0, vr = 0;
         float vlo = 0, vro = 0;
         float lfovalue = globalLFO.getVal();
         float viblfo = vibratoLFO.getVal() * vibratoAmount * vibratoAmount * 4.f;
         float lfovalue2 = 0, viblfo2 = 0;
+
         if (oversample)
         {
             globalLFO.update();

--- a/src/engine/SynthEngine.h
+++ b/src/engine/SynthEngine.h
@@ -40,6 +40,10 @@ class SynthEngine
     Smoother modWheelSmoother;
     float sampleRate;
 
+    // clever trick to avoid nested ternary, which provides 0.f -> 0.f, 0.5f -> 1.f, 1.f -> -1.f
+    // we use it for inverting LFO modulations per target via tri-state buttons
+    float remapZeroHalfOneToZeroOneMinusOne(float x) { return (5 * x) - (6 * x * x); }
+
     // JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (SynthEngine)
 
   public:
@@ -75,6 +79,8 @@ class SynthEngine
     }
 
     float getVoiceStatus(uint8_t idx) { return synth.voices[idx].getVoiceStatus(); };
+
+    Motherboard *getMotherboard() { return &synth; };
 
     void allNotesOff()
     {
@@ -217,32 +223,32 @@ class SynthEngine
     }
     void processLFO1ToOsc1Pitch(float val)
     {
-        const auto v = (val == 0.5f ? 1.f : ((val == 1.f) ? -1.f : 0.f));
+        const auto v = remapZeroHalfOneToZeroOneMinusOne(val);
         ForEachVoice(lfoo1 = v);
     }
     void processLFO1ToOsc2Pitch(float val)
     {
-        const auto v = (val == 0.5f ? 1.f : ((val == 1.f) ? -1.f : 0.f));
+        const auto v = remapZeroHalfOneToZeroOneMinusOne(val);
         ForEachVoice(lfoo2 = v);
     }
     void processLFO1ToFilterCutoff(float val)
     {
-        const auto v = (val == 0.5f ? 1.f : ((val == 1.f) ? -1.f : 0.f));
+        const auto v = remapZeroHalfOneToZeroOneMinusOne(val);
         ForEachVoice(lfof = v);
     }
     void processLFO1ToOsc1PW(float val)
     {
-        const auto v = (val == 0.5f ? 1.f : ((val == 1.f) ? -1.f : 0.f));
+        const auto v = remapZeroHalfOneToZeroOneMinusOne(val);
         ForEachVoice(lfopw1 = v);
     }
     void processLFO1ToOsc2PW(float val)
     {
-        const auto v = (val == 0.5f ? 1.f : ((val == 1.f) ? -1.f : 0.f));
+        const auto v = remapZeroHalfOneToZeroOneMinusOne(val);
         ForEachVoice(lfopw2 = v);
     }
     void processLFO1ToVolume(float val)
     {
-        const auto v = (val == 0.5f ? 1.f : ((val == 1.f) ? -1.f : 0.f));
+        const auto v = remapZeroHalfOneToZeroOneMinusOne(val);
         ForEachVoice(lfovol = v);
     }
     void processUnisonDetune(float val)


### PR DESCRIPTION
Closes #151.

Also add a remapping function to SynthEngine that replaces nested ternary when setting LFO target tri-state buttons - it's more performant!