### PR TITLE
dynamically unload the previous asset when crossing boundary

### DIFF
--- a/src/components/ScalingImageCache.cpp
+++ b/src/components/ScalingImageCache.cpp
@@ -114,7 +114,7 @@ void ScalingImageCache::guaranteeImageFor(const std::string &label, const int zo
 {
     auto &imgMap = cacheImages[label];
 
-    for (auto it = imgMap.begin(); it != imgMap.end(); )
+    for (auto it = imgMap.begin(); it != imgMap.end();)
     {
         if (it->first != zoomLevel)
             it = imgMap.erase(it);


### PR DESCRIPTION
does what it says on the tin 