### PR TITLE
Reset decimator on oversample toggle

### DIFF
--- a/src/engine/Decimator.h
+++ b/src/engine/Decimator.h
@@ -61,6 +61,11 @@ class Decimator17
   public:
     Decimator17() {}
 
+    void resetDecimator()
+    {
+        R1 = R2 = R3 = R4 = R5 = R6 = R7 = R8 = R9 = R10 = R11 = R12 = R13 = R14 = R15 = R16 = R17 =
+            0.f;
+    }
     float decimate(const float x0, const float x1)
     {
         float h17x0 = h17 * x0;

--- a/src/engine/Motherboard.h
+++ b/src/engine/Motherboard.h
@@ -560,6 +560,8 @@ class Motherboard
         }
 
         oversample = over;
+        left.resetDecimator();
+        right.resetDecimator();
     }
 
     inline float processSynthVoice(Voice &b, float lfoIn, float vibIn)


### PR DESCRIPTION
Otherwise we may get bad clicks, nans, etc...