### PR TITLE
Partlly revert 098b044424727894f9d5dfca13ff002549d0966d

### DIFF
--- a/src/parameter/ParameterManager.cpp
+++ b/src/parameter/ParameterManager.cpp
@@ -118,7 +118,7 @@ void ParameterManager::updateParameters(const bool force)
             {
                 // the set methods *shoudl* be idempotent but in the event
                 // they aren't we don't want to clobber them with no change
-                if (par->getValue() != newParam.second.newValue)
+                if (true) // par->getValue() != newParam.second.newValue)
                 {
 #if DEBUG_PARAM_SETS
                     processedParams += juce::String(newParam.second.parameterID) + "=" +


### PR DESCRIPTION
The prior commit didn't work for things with explicit sets like buttons, double click, and more, even though it fixed the open-editor pop.

So back to drawing board a bit.