### PR TITLE
More protection against non-changes

### DIFF
--- a/src/engine/Motherboard.h
+++ b/src/engine/Motherboard.h
@@ -100,16 +100,24 @@ class Motherboard
 
     void setPolyphony(int count)
     {
-        totalVoiceCount = std::min(count, MAX_VOICES);
+        auto newCount = std::min(count, MAX_VOICES);
+        if (newCount != totalVoiceCount)
+        {
+            totalVoiceCount = newCount;
 
-        resetVoiceQueueCount();
+            resetVoiceQueueCount();
+        }
     }
 
     void setUnisonVoices(int count)
     {
-        unisonVoiceCount = std::min(count, MAX_VOICES);
+        auto newCount = std::min(count, MAX_PANNINGS);
+        if (newCount != unisonVoiceCount)
+        {
+            unisonVoiceCount = newCount;
 
-        resetVoiceQueueCount();
+            resetVoiceQueueCount();
+        }
     }
 
     void resetVoiceQueueCount()

--- a/src/parameter/ParameterManager.cpp
+++ b/src/parameter/ParameterManager.cpp
@@ -116,16 +116,11 @@ void ParameterManager::updateParameters(const bool force)
         {
             if (auto par = getParameter(newParam.second.parameterID))
             {
-                // the set methods *shoudl* be idempotent but in the event
-                // they aren't we don't want to clobber them with no change
-                if (true) // par->getValue() != newParam.second.newValue)
-                {
 #if DEBUG_PARAM_SETS
                     processedParams += juce::String(newParam.second.parameterID) + "=" +
                                        juce::String(newParam.second.newValue) + ", ";
 #endif
-                    it->second(newParam.second.newValue, false);
-                }
+                it->second(newParam.second.newValue, false);
 #if DEBUG_PARAM_SETS
                 processed++;
 #endif


### PR DESCRIPTION
I can't repro the click but we don't want to do this voice queue reset if nothing has changed.