### PR TITLE
LV2 is cross platform

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,14 +91,10 @@ add_compile_definitions(JUCE_USE_CURL=0)
 
 include(cmake/get_dependencies.cmake)
 
-list(APPEND OBXF_JUCE_FORMATS VST3 Standalone)
+list(APPEND OBXF_JUCE_FORMATS VST3 LV2 Standalone)
 
 if(APPLE)
     list(APPEND OBXF_JUCE_FORMATS AU)
-endif()
-
-if(UNIX AND NOT APPLE)
-    list(APPEND OBXF_JUCE_FORMATS LV2)
 endif()
 
 juce_add_plugin(OB-Xf


### PR DESCRIPTION
There is no reason to build LV2 only for "UNIX AND NOT APPLE".

Afaik you can also put AU in the list of formats and it will only be built for macOS, so no need for these additional checks.