### PR TITLE
Fix a wierd reported linux version bug

### DIFF
--- a/cmake/get_dependencies.cmake
+++ b/cmake/get_dependencies.cmake
@@ -65,6 +65,8 @@
 
     # Fetch order means the main cmake runs before git so ugh
     configure_file(${sstplugininfra_SOURCE_DIR}/src/version_information_in.cpp ${CMAKE_BINARY_DIR}/obxfi/version_information.cpp)
+    file(COPY ${CMAKE_BINARY_DIR}/obxfi/version_information.cpp
+            DESTINATION ${CMAKE_BINARY_DIR}/geninclude/)
     add_library(obxf_version_information STATIC)
     target_sources(obxf_version_information PRIVATE  ${CMAKE_BINARY_DIR}/obxfi/version_information.cpp)
     target_include_directories(obxf_version_information PUBLIC ${sstplugininfra_SOURCE_DIR}/include)


### PR DESCRIPTION
even though ci and all our dev builds use the obxfi version of version info, one linux debian user reported they were getting the geninclude stub version. So make them sync rather than solve that non-reproducible-by-us issue.

Closes #246