### PR TITLE
Improve behavior of LFO to volume modulation

### DIFF
--- a/src/engine/Lfo.h
+++ b/src/engine/Lfo.h
@@ -175,7 +175,7 @@ class LFO
             static_cast<float>(juce::dsp::FastMathApproximations::sin<double>(state.phase));
         state.wave.tri =
             (twoByPi * abs(state.phase + halfPi - (state.phase > halfPi) * twoPi)) - 1.f;
-        state.wave.square = (state.phase > (pi * par.pw * 0.9f) ? 1.f : -1.f + par.unipolarPulse);
+        state.wave.square = (state.phase > (pi * par.pw * 0.9f) ? -1.f + par.unipolarPulse : 1.f);
         state.wave.saw = bend(-state.phase * invPi, -par.pw);
         state.wave.sampleglide = state.wave.history + (state.wave.samplehold - state.wave.history) *
                                                           (pi + state.phase) * invTwoPi;


### PR DESCRIPTION
Previously, we could go above unity gain with inverted modulation, now we just invert the waveform (which is how it should have been).

Also modified the LFO so that it is high first then low (it was inverted until now), this matches the icon on the GUI