### PR TITLE
Force execute SetHQ() when calling Motherboard::setSampleRate()

### DIFF
--- a/src/engine/Motherboard.h
+++ b/src/engine/Motherboard.h
@@ -156,7 +156,9 @@ class Motherboard
             voices[i].setSampleRate(sr);
         }
 
-        SetHQMode(oversample);
+        // always execute this when setting SR for the motherboard
+        // see GitHub issue #269
+        SetHQMode(oversample, true);
     }
 
     void sustainOn()
@@ -556,9 +558,9 @@ class Motherboard
         dumpVoiceStatus();
     }
 
-    void SetHQMode(bool over)
+    void SetHQMode(bool over, bool force = false)
     {
-        if (over == oversample)
+        if (!force && over == oversample)
         {
             return;
         }
@@ -570,8 +572,8 @@ class Motherboard
 
         for (int i = 0; i < MAX_VOICES; i++)
         {
-            voices[i].setHQMode(over);
             voices[i].setSampleRate(sampleRate * factor);
+            voices[i].setHQMode(over);
         }
 
         oversample = over;

--- a/src/engine/SynthEngine.h
+++ b/src/engine/SynthEngine.h
@@ -461,10 +461,14 @@ class SynthEngine
     inline void processFilterModeSmoothed(float val) { ForEachVoice(filter.setMultimode(val)); }
     void processHQMode(float val)
     {
-        bool nover = val > 0.5f;
-        if (nover != synth.oversample)
+        bool v = val > 0.5f;
+
+        if (v != synth.oversample)
+        {
             allSoundOff();
-        synth.SetHQMode(nover);
+        }
+
+        synth.SetHQMode(v);
     }
     void processFilterEnvAmount(float val)
     {


### PR DESCRIPTION
This fixes the issue where renders sounded an octave higher if HQ button was enabled. The cause was a SR mismatch because JUCE's prepareToPlay sent us host's SR (say 48k), this propagated throughout the synth, but HQ stuff was not being executed because Motherboard::SetHQ() was guarded by an early return if incoming value was the same as the `oversample` member.

Added a force argument to Motherboard::SetHQ() which is then only called from Motherboard::setSampleRate().

Fixes #269!