### PR TITLE
Make all buttons trigger on mouse down

### DIFF
--- a/src/PluginEditor.cpp
+++ b/src/PluginEditor.cpp
@@ -1937,6 +1937,7 @@ std::unique_ptr<ToggleButton> ObxfAudioProcessorEditor::addButton(const int x, c
     button->setBounds(x, y, w, h);
     button->setButtonText(name);
     button->setTitle(name);
+    button->setTriggeredOnMouseDown(true);
 
     addAndMakeVisible(button);
 


### PR DESCRIPTION
It was on mouse up until now. Multibuttons already triggered on mouse down. This makes all buttons behave consistently.