### PR TITLE
Towards SVG Skins; an SVG Knob

### DIFF
--- a/src/PluginEditor.cpp
+++ b/src/PluginEditor.cpp
@@ -227,6 +227,8 @@ void ObxfAudioProcessorEditor::loadTheme(ObxfAudioProcessor &ownerFilter)
 {
     skinLoaded = false;
 
+    DBG("Setting theme to " << themeFolder.getFullPathName());
+
     if (!loadThemeFilesAndCheck())
         return;
 
@@ -245,14 +247,17 @@ void ObxfAudioProcessorEditor::loadTheme(ObxfAudioProcessor &ownerFilter)
     }
 
     if (cachedThemeXml->getTagName() == "obxf-theme")
+    {
+        imageCache.clearCache();
+        imageCache.skinDir = themeFolder;
+
         createComponentsFromXml(cachedThemeXml.get());
+    }
 
     setupMenus();
     restoreComponentParameterValues(parameterValues);
     finalizeThemeLoad(ownerFilter);
     resized();
-
-    imageCache.skinDir = themeFolder;
 }
 
 bool ObxfAudioProcessorEditor::loadThemeFilesAndCheck()

--- a/src/components/ScalingImageCache.h
+++ b/src/components/ScalingImageCache.h
@@ -32,6 +32,10 @@ struct ScalingImageCache
 {
 
     explicit ScalingImageCache(Utils &utilsRef);
+    bool isSVG(const std::string &label);
+    int getSvgLayerCount(const std::string &label);
+    std::unique_ptr<juce::Drawable> &getSVGDrawable(const std::string &label, int layer = -1);
+
     juce::Image getImageFor(const std::string &label, int w, int h);
     int zoomLevelFor(const std::string &label, int w, int h);
     void clearCache();
@@ -42,6 +46,9 @@ struct ScalingImageCache
     void guaranteeImageFor(const std::string &label, int zoomLevel);
     void setSkinDir();
     Utils &utils;
+
+    std::unordered_map<std::string, int> svgLayerCount;
+    std::unordered_map<std::string, std::vector<std::unique_ptr<juce::Drawable>>> svgLayers;
 
     std::unordered_map<std::string, std::map<int, juce::File>> cachePaths;
     std::unordered_map<std::string, std::map<int, std::optional<juce::Image>>> cacheImages;


### PR DESCRIPTION
1. Update the ImageCache so that it has an SVG branch
   - If foo.png isn't there and foo.svg is then isSVG("foo") will return true and so forth
   - if foo_layer1.svg foo_layer2.svg is there the the layer count mechanism kicks in

2. Modify the knob class to be either one layer and rotate it or multiple layers as non-rot base, rot mid optional non-rot top as 1/2/3

3. FIx a problem in skin swapping that the image cache didn't reset correctly.