### PR TITLE
Fix a variety of temposync problems

### DIFF
--- a/src/PluginProcessor.h
+++ b/src/PluginProcessor.h
@@ -211,6 +211,10 @@ class ObxfAudioProcessor final : public juce::AudioProcessor,
 
     std::unique_ptr<StateManager> state;
 
+    bool wasPlayingLastFrame{false};
+    double lastPPQPosition{-1};
+    double syntheticPPQPosition{-1};
+
     void initializeCallbacks();
 
     void initializeMidiCallbacks();

--- a/src/engine/Lfo.h
+++ b/src/engine/Lfo.h
@@ -93,13 +93,16 @@ class LFO
         }
     }
 
-    void hostSyncRetrigger(float bpm, float quarters)
+    void hostSyncRetrigger(float bpm, float quarters, bool resetPosition)
     {
         if (state.tempoSynced)
         {
             state.phaseInc = (bpm / 60.f) * state.syncedRate;
-            state.phase = state.phaseInc * quarters;
-            state.phase -= fmod(state.phase, 1.f) * twoPi - pi;
+            if (resetPosition)
+            {
+                state.phase = state.phaseInc * quarters;
+                state.phase -= fmod(state.phase, 1.f) * twoPi - pi;
+            }
         }
     }
 

--- a/src/engine/SynthEngine.h
+++ b/src/engine/SynthEngine.h
@@ -62,7 +62,10 @@ class SynthEngine
 
     ~SynthEngine() {}
 
-    void setPlayHead(float bpm, float retrPos) { synth.globalLFO.hostSyncRetrigger(bpm, retrPos); }
+    void setPlayHead(float bpm, float retrPos, bool resetPosition)
+    {
+        synth.globalLFO.hostSyncRetrigger(bpm, retrPos, resetPosition);
+    }
 
     void setSampleRate(float sr)
     {


### PR DESCRIPTION
1. If the tempo changes but the transport direction does not (so haven't looped, haven't just started playback) then change the phase increment but not the phase of sync.

2. If there's no playhead, make an artificial 120bpm playhead which is always playing form outset