### PR TITLE
Add support for multiple theme locations

### DIFF
--- a/src/PluginEditor.h
+++ b/src/PluginEditor.h
@@ -228,7 +228,7 @@ class ObxfAudioProcessorEditor final : public juce::AudioProcessorEditor,
     std::array<std::unique_ptr<Label>, MAX_VOICES> voiceLEDs, voiceBGs;
     std::array<std::vector<juce::Component *>, NUM_LFOS> lfoControls;
 
-    juce::File themeFolder;
+    Utils::ThemeLocation themeLocation;
 
     std::vector<std::unique_ptr<KnobAttachment>> knobAttachments;
     std::vector<std::unique_ptr<ButtonAttachment>> toggleAttachments;
@@ -253,7 +253,7 @@ class ObxfAudioProcessorEditor final : public juce::AudioProcessorEditor,
 
     float impliedScaleFactor() const;
 
-    std::vector<juce::File> themes;
+    std::vector<Utils::ThemeLocation> themes;
     std::vector<juce::File> banks;
     std::unique_ptr<juce::FileChooser> fileChooser;
     juce::FontOptions patchNameFont;

--- a/src/Utils.h
+++ b/src/Utils.h
@@ -53,26 +53,37 @@ class Utils final
 {
   public:
     Utils();
-
     ~Utils();
+
+    enum LocationType
+    {
+        FACTORY,
+        USER
+    };
 
     // File System Methods
     [[nodiscard]] juce::File getFactoryFolder() const;
-
     [[nodiscard]] juce::File getDocumentFolder() const;
-
     [[nodiscard]] juce::File getMidiFolder() const;
-
-    [[nodiscard]] juce::File getThemeFolder() const;
-
     [[nodiscard]] juce::File getBanksFolder() const;
 
     // Theme Management
-    [[nodiscard]] const std::vector<juce::File> &getThemeFiles() const;
+    struct ThemeLocation
+    {
+        LocationType locationType;
+        juce::String dirName;
+        juce::File file;
 
-    [[nodiscard]] juce::File getCurrentThemeFolder() const;
-
-    void setCurrentThemeFolder(const juce::String &folderName);
+        bool operator==(const ThemeLocation &other) const
+        {
+            return locationType == other.locationType && dirName == other.dirName;
+        }
+    };
+    [[nodiscard]] std::vector<juce::File> getThemeFolders() const;
+    [[nodiscard]] juce::File getThemeFolderFor(LocationType loc) const;
+    [[nodiscard]] const std::vector<ThemeLocation> &getThemeLocations() const;
+    [[nodiscard]] ThemeLocation getCurrentThemeLocation() const;
+    void setCurrentThemeLocation(const ThemeLocation &loc);
 
     void scanAndUpdateThemes();
 
@@ -159,11 +170,11 @@ class Utils final
     void updateConfig();
 
     // File Collections
-    std::vector<juce::File> themeFiles;
+    std::vector<ThemeLocation> themeLocations;
     std::vector<juce::File> bankFiles;
 
     // Current States
-    juce::String currentTheme;
+    ThemeLocation currentTheme;
     juce::String currentBank;
     int gui_size{};
     float physicalPixelScaleFactor{};

--- a/src/components/ScalingImageCache.cpp
+++ b/src/components/ScalingImageCache.cpp
@@ -173,7 +173,7 @@ void ScalingImageCache::guaranteeImageFor(const std::string &label, const int zo
 
 void ScalingImageCache::setSkinDir()
 {
-    if (const juce::File theme = utils.getCurrentThemeFolder(); theme.isDirectory())
+    if (const juce::File theme = utils.getCurrentThemeLocation().file; theme.isDirectory())
         skinDir = theme;
 }
 


### PR DESCRIPTION
Allow themes to come from both factory and user directories. Store the directory type and name in config
Use a data structure rather than a raw juce::File to represent a theme If the theme is non-configurable and some were found pick the first which closes #299

but this generally is the path towards #7