### PR TITLE
Generally fix up the param-to-string normalization errors

### DIFF
--- a/src/gui/Knob.h
+++ b/src/gui/Knob.h
@@ -250,7 +250,9 @@ class Knob final : public juce::Slider, public juce::ActionBroadcaster
     juce::String getTextFromValue(double value) override
     {
         if (auto *op = dynamic_cast<ObxfParameterFloat *>(parameter))
-            return op->stringFromValue(static_cast<float>(value), 0).c_str();
+        {
+            return op->stringFromValue(static_cast<float>(op->denormalizedValue(value)), 0).c_str();
+        }
         return juce::String(value);
     }
 

--- a/src/parameter/ParameterList.h
+++ b/src/parameter/ParameterList.h
@@ -72,43 +72,43 @@ static const std::vector<ParameterInfo> ParameterList{
     {ID::Tune, pmd().asFloat().withName(Name::Tune).withRange(-100.f, 100.f).withLinearScaleFormatting("cents").withDecimalPlaces(1).withID(5150)},
 
     // <-- GLOBAL -->
-    {ID::Polyphony, pmd().asInt().withName(Name::Polyphony).withRange(1, MAX_VOICES).withDefault(8).withID(8675309)},
-    {ID::HQMode, pmd().asBool().withName(Name::HQMode).withID(90210)},
+    {ID::Polyphony, pmd().asInt().withLinearScaleFormatting("Voices").withName(Name::Polyphony).withRange(1, MAX_VOICES).withDefault(8).withID(8675309)},
+    {ID::HQMode, pmd().asOnOffBool().withName(Name::HQMode).withID(90210)},
 
-    {ID::UnisonVoices, pmd().asInt().withName(Name::UnisonVoices).withRange(1, 8).withDefault(8).withID(0101101)},
+    {ID::UnisonVoices, pmd().asInt().withLinearScaleFormatting("Voices").withName(Name::UnisonVoices).withRange(1, 8).withDefault(8).withID(0101101)},
 
 
     {ID::Portamento, pmd().asFloat().withName(Name::Portamento).withRange(0.f, 1.f).asPercent().withDecimalPlaces(1).withID(1979)},
-    {ID::Unison, pmd().asBool().withName(Name::Unison).withID(8)},
+    {ID::Unison, pmd().asOnOffBool().withName(Name::Unison).withID(8)},
     {ID::UnisonDetune, pmd().asFloat().withName(Name::UnisonDetune).withRange(0.f, 1.f).asPercent().withDefault(0.25f).withDecimalPlaces(1).withID(9846)},
 
-    {ID::EnvLegatoMode, pmd().asInt().withName(Name::EnvLegatoMode).withRange(0, 3).withID(12340)},
-    {ID::NotePriority, pmd().asInt().withName(Name::NotePriority).withRange(0, 2).withID(153251)},
+    {ID::EnvLegatoMode, pmd().asInt().withName(Name::EnvLegatoMode).withRange(0, 3).withID(12340).withUnorderedMapFormatting({{0, "Both Legato"}, {1, "Retrigger FEG"}, {2, "Retriger AEG"}, {3, "Always Retrigger"}})},
+    {ID::NotePriority, pmd().asInt().withName(Name::NotePriority).withRange(0, 2).withID(153251).withUnorderedMapFormatting({{0, "Last"}, {1, "Low"}, {2, "High"}})},
 
     // <-- OSCILLATORS -->
     {ID::Osc1Pitch, pmd().asFloat().withName(Name::Osc1Pitch).asSemitoneRange(-24.f, 24.f).withDecimalPlaces(2).withID(12352)},
     {ID::Osc2Detune, pmd().asFloat().withName(Name::Osc2Detune).withRange(0.f, 1.f).withOBXFLogScale(0.1f, 100.f, 0.001f, "cents").withDecimalPlaces(1).withID(1345443)},
     {ID::Osc2Pitch, pmd().asFloat().withName(Name::Osc2Pitch).asSemitoneRange(-24.f, 24.f).withDecimalPlaces(2).withID(124)},
 
-    {ID::Osc1SawWave, pmd().asBool().withName(Name::Osc1SawWave).withDefault(1.f).withID(122235)},
-    {ID::Osc1PulseWave, pmd().asBool().withName(Name::Osc1PulseWave).withID(323116)},
+    {ID::Osc1SawWave, pmd().asOnOffBool().withName(Name::Osc1SawWave).withDefault(1.f).withID(122235)},
+    {ID::Osc1PulseWave, pmd().asOnOffBool().withName(Name::Osc1PulseWave).withID(323116)},
 
-    {ID::Osc2SawWave, pmd().asBool().withName(Name::Osc2SawWave).withDefault(1.f).withID(4357)},
-    {ID::Osc2PulseWave, pmd().asBool().withName(Name::Osc2PulseWave).withID(76818)},
+    {ID::Osc2SawWave, pmd().asOnOffBool().withName(Name::Osc2SawWave).withDefault(1.f).withID(4357)},
+    {ID::Osc2PulseWave, pmd().asOnOffBool().withName(Name::Osc2PulseWave).withID(76818)},
 
     {ID::OscPW, pmd().asFloat().withName(Name::OscPW).withRange(0.f, 1.f).withExtendFactors(47.5f, 50.f).withLinearScaleFormatting("%").withDecimalPlaces(1).withID(9859834)},
     {ID::Osc2PWOffset, pmd().asFloat().withName(Name::Osc2PWOffset).withRange(0.f, 1.f).withExtendFactors(47.5f, 0.f).withLinearScaleFormatting("%").withDecimalPlaces(1).withID(232240)},
 
     {ID::EnvToPitchAmount, pmd().asFloat().withName(Name::EnvToPitchAmount).asSemitoneRange(0.f, 36.f).withDecimalPlaces(2).withID(7878921)},
-    {ID::EnvToPitchBothOscs, pmd().asBool().withName(Name::EnvToPitchBothOscs).withDefault(1.f).withID(222232)},
-    {ID::EnvToPitchInvert, pmd().asBool().withName(Name::EnvToPitchInvert).withID(23678)},
+    {ID::EnvToPitchBothOscs, pmd().asOnOffBool().withName(Name::EnvToPitchBothOscs).withDefault(1.f).withID(222232)},
+    {ID::EnvToPitchInvert, pmd().asOnOffBool().withName(Name::EnvToPitchInvert).withID(23678)},
 
     {ID::EnvToPWAmount, pmd().asFloat().withName(Name::EnvToPWAmount).withRange(0.f, 1.f).asPercent().withDecimalPlaces(1).withID(7824)},
-    {ID::EnvToPWBothOscs, pmd().asBool().withName(Name::EnvToPWBothOscs).withDefault(1.f).withID(22235)},
-    {ID::EnvToPWInvert, pmd().asBool().withName(Name::EnvToPWInvert).withID(9926)},
+    {ID::EnvToPWBothOscs, pmd().asOnOffBool().withName(Name::EnvToPWBothOscs).withDefault(1.f).withID(22235)},
+    {ID::EnvToPWInvert, pmd().asOnOffBool().withName(Name::EnvToPWInvert).withID(9926)},
 
     {ID::OscCrossmod, pmd().asFloat().withName(Name::OscCrossmod).withRange(0.f, 1.f).asPercent().withDecimalPlaces(1).withID(298647)},
-    {ID::OscSync, pmd().asBool().withName(Name::OscSync).withID(28778979)},
+    {ID::OscSync, pmd().asOnOffBool().withName(Name::OscSync).withID(28778979)},
     {ID::OscBrightness, pmd().asFloat().withName(Name::OscBrightness).withRange(0.f, 1.f).asPercent().withDefault(1.f).withDecimalPlaces(1).withID(255779)},
 
     // <-- MIXER -->
@@ -119,15 +119,15 @@ static const std::vector<ParameterInfo> ParameterList{
     {ID::NoiseColor, pmd().asFloat().withName(Name::NoiseColor).withRange(0.f, 1.f).withQuantizedStepCount(3).withID(667834)},
 
     // <-- CONTROL -->
-    {ID::BendUpRange, pmd().asInt().withName(Name::BendUpRange).withRange(0, MAX_BEND_RANGE).withDefault(2).withID(3121235)},
-    {ID::BendDownRange, pmd().asInt().withName(Name::BendDownRange).withRange(0, MAX_BEND_RANGE).withDefault(2).withID(9800936)},
-    {ID::BendOsc2Only, pmd().asBool().withName(Name::BendOsc2Only).withID(979737)},
+    {ID::BendUpRange, pmd().asInt().withLinearScaleFormatting("Semitones").withName(Name::BendUpRange).withRange(0, MAX_BEND_RANGE).withDefault(2).withID(3121235)},
+    {ID::BendDownRange, pmd().asInt().withLinearScaleFormatting("Semitones").withName(Name::BendDownRange).withRange(0, MAX_BEND_RANGE).withDefault(2).withID(9800936)},
+    {ID::BendOsc2Only, pmd().asOnOffBool().withName(Name::BendOsc2Only).withID(979737)},
 
-    {ID::VibratoWave, pmd().asBool().withName(Name::VibratoWave).withID(938)},
+    {ID::VibratoWave, pmd().asOnOffBool().withName(Name::VibratoWave).withID(938)},
     {ID::VibratoRate, pmd().asFloat().withName(Name::VibratoRate).withRange(0.f, 1.f).withExtendFactors(10.f, 2.f).withLinearScaleFormatting("Hz").withDefault(0.3f).withDecimalPlaces(2).withID(13239)},
 
     // <-- FILTER -->
-    {ID::Filter4PoleMode, pmd().asBool().withName(Name::Filter4PoleMode).withID(402)},
+    {ID::Filter4PoleMode, pmd().asOnOffBool().withName(Name::Filter4PoleMode).withID(402)},
 
     {ID::FilterCutoff, pmd().asFloat().withName(Name::FilterCutoff).withRange(-45.f, 75.f).withATwoToTheBFormatting(440.f, 1.f / 12.f, "Hz").withDefault(75.f).withDecimalPlaces(1).withID(4341)},
     {ID::FilterResonance, pmd().asFloat().withName(Name::FilterResonance).withRange(0.f, 1.f).asPercent().withDecimalPlaces(1).withID(44562)},
@@ -136,14 +136,14 @@ static const std::vector<ParameterInfo> ParameterList{
     {ID::FilterKeyFollow, pmd().asFloat().withName(Name::FilterKeyFollow).withRange(0.f, 1.f).asPercent().withDecimalPlaces(1).withID(21244467)},
     {ID::FilterMode, pmd().asFloat().withName(Name::FilterMode).withRange(0.f, 1.f).asPercent().withDecimalPlaces(1).withID(433455)},
 
-    {ID::Filter2PoleBPBlend, pmd().asBool().withName(Name::Filter2PoleBPBlend).withID(456889)},
-    {ID::Filter2PolePush, pmd().asBool().withName(Name::Filter2PolePush).withID(7747)},
+    {ID::Filter2PoleBPBlend, pmd().asOnOffBool().withName(Name::Filter2PoleBPBlend).withID(456889)},
+    {ID::Filter2PolePush, pmd().asOnOffBool().withName(Name::Filter2PolePush).withID(7747)},
 
-    {ID::Filter4PoleXpander, pmd().asBool().withName(Name::Filter4PoleXpander).withID(999666)},
+    {ID::Filter4PoleXpander, pmd().asOnOffBool().withName(Name::Filter4PoleXpander).withID(999666)},
     {ID::FilterXpanderMode, pmd().asInt().withName(Name::FilterXpanderMode).withRange(0, 14).withID(666999)},
 
     // <-- LFO 1 -->
-    {ID::LFO1TempoSync, pmd().asBool().withName(Name::LFO1TempoSync).withID(9948)},
+    {ID::LFO1TempoSync, pmd().asOnOffBool().withName(Name::LFO1TempoSync).withID(9948)},
 
     {ID::LFO1Rate, pmd().withName(Name::LFO1Rate).withRange(0.f, 1.f).temposyncable(true).withOBXFLogScale(0, 250, 3775.f, "Hz").withDefault(0.5f).withDecimalPlaces(2).withID(45649)},
     {ID::LFO1ModAmount1, pmd().asFloat().withName(Name::LFO1ModAmount1).withRange(0.f, 1.f).asPercent().withDecimalPlaces(1).withID(45650)},
@@ -155,16 +155,16 @@ static const std::vector<ParameterInfo> ParameterList{
 
     {ID::LFO1PW, pmd().asFloat().withName(Name::LFO1PW).withRange(0.f, 1.f).withExtendFactors(45.f, 50.f).withLinearScaleFormatting("%").withDecimalPlaces(1).withID(56755)},
 
-    {ID::LFO1ToOsc1Pitch, pmd().asBool().withName(Name::LFO1ToOsc1Pitch).withID(546756)},
-    {ID::LFO1ToOsc2Pitch, pmd().asBool().withName(Name::LFO1ToOsc2Pitch).withID(45657)},
-    {ID::LFO1ToFilterCutoff, pmd().asBool().withName(Name::LFO1ToFilterCutoff).withID(645658)},
+    {ID::LFO1ToOsc1Pitch, pmd().asOnOffBool().withName(Name::LFO1ToOsc1Pitch).withID(546756)},
+    {ID::LFO1ToOsc2Pitch, pmd().asOnOffBool().withName(Name::LFO1ToOsc2Pitch).withID(45657)},
+    {ID::LFO1ToFilterCutoff, pmd().asOnOffBool().withName(Name::LFO1ToFilterCutoff).withID(645658)},
 
-    {ID::LFO1ToOsc1PW, pmd().asBool().withName(Name::LFO1ToOsc1PW).withID(768759)},
-    {ID::LFO1ToOsc2PW, pmd().asBool().withName(Name::LFO1ToOsc2PW).withID(67860)},
-    {ID::LFO1ToVolume, pmd().asBool().withName(Name::LFO1ToVolume).withID(667761)},
+    {ID::LFO1ToOsc1PW, pmd().asOnOffBool().withName(Name::LFO1ToOsc1PW).withID(768759)},
+    {ID::LFO1ToOsc2PW, pmd().asOnOffBool().withName(Name::LFO1ToOsc2PW).withID(67860)},
+    {ID::LFO1ToVolume, pmd().asOnOffBool().withName(Name::LFO1ToVolume).withID(667761)},
 
     // <-- LFO 2 -->
-    {ID::LFO2TempoSync, pmd().asBool().withName(Name::LFO2TempoSync).withID(7245678)},
+    {ID::LFO2TempoSync, pmd().asOnOffBool().withName(Name::LFO2TempoSync).withID(7245678)},
 
     {ID::LFO2Rate, pmd().withName(Name::LFO2Rate).withRange(0.f, 1.f).temposyncable(true).withOBXFLogScale(0, 250, 3775.f, "Hz").withDefault(0.5f).withDecimalPlaces(2).withID(236345)},
     {ID::LFO2ModAmount1, pmd().asFloat().withName(Name::LFO2ModAmount1).withRange(0.f, 1.f).asPercent().withDecimalPlaces(1).withID(375638)},
@@ -176,16 +176,16 @@ static const std::vector<ParameterInfo> ParameterList{
 
     {ID::LFO2PW, pmd().asFloat().withName(Name::LFO2PW).withRange(0.f, 1.f).withExtendFactors(45.f, 50.f).withLinearScaleFormatting("%").withDecimalPlaces(1).withID(45678765)},
 
-    {ID::LFO2ToOsc1Pitch, pmd().asBool().withName(Name::LFO2ToOsc1Pitch).withID(1010696)},
-    {ID::LFO2ToOsc2Pitch, pmd().asBool().withName(Name::LFO2ToOsc2Pitch).withID(2049961)},
-    {ID::LFO2ToFilterCutoff, pmd().asBool().withName(Name::LFO2ToFilterCutoff).withID(95890497)},
+    {ID::LFO2ToOsc1Pitch, pmd().asOnOffBool().withName(Name::LFO2ToOsc1Pitch).withID(1010696)},
+    {ID::LFO2ToOsc2Pitch, pmd().asOnOffBool().withName(Name::LFO2ToOsc2Pitch).withID(2049961)},
+    {ID::LFO2ToFilterCutoff, pmd().asOnOffBool().withName(Name::LFO2ToFilterCutoff).withID(95890497)},
 
-    {ID::LFO2ToOsc1PW, pmd().asBool().withName(Name::LFO2ToOsc1PW).withID(51034956)},
-    {ID::LFO2ToOsc2PW, pmd().asBool().withName(Name::LFO2ToOsc2PW).withID(1058774325)},
-    {ID::LFO2ToVolume, pmd().asBool().withName(Name::LFO2ToVolume).withID(984477567)},
+    {ID::LFO2ToOsc1PW, pmd().asOnOffBool().withName(Name::LFO2ToOsc1PW).withID(51034956)},
+    {ID::LFO2ToOsc2PW, pmd().asOnOffBool().withName(Name::LFO2ToOsc2PW).withID(1058774325)},
+    {ID::LFO2ToVolume, pmd().asOnOffBool().withName(Name::LFO2ToVolume).withID(984477567)},
 
     // <-- FILTER ENVELOPE -->
-    {ID::FilterEnvInvert, pmd().asBool().withName(Name::FilterEnvInvert).withID(2262)},
+    {ID::FilterEnvInvert, pmd().asOnOffBool().withName(Name::FilterEnvInvert).withID(2262)},
 
     {ID::FilterEnvAttack, pmd().asFloat().withName(Name::FilterEnvAttack).withRange(0.f, 1.f).withOBXFLogScale(1.f, 60000.f, 900.f, "ms").withDisplayRescalingAbove(1000.f, 0.001f, "s").withID(33563)},
     {ID::FilterEnvDecay, pmd().asFloat().withName(Name::FilterEnvDecay).withRange(0.f, 1.f).withOBXFLogScale(1.f, 60000.f, 900.f, "ms").withDisplayRescalingAbove(1000.f, 0.001f, "s").withID(62344)},
@@ -220,7 +220,7 @@ static const std::vector<ParameterInfo> ParameterList{
     {ID::PanVoice8, customPan().withName(Name::PanVoice8).withID(63584)},
 
     // <! -- OTHER -->
-    {ID::EcoMode, pmd().asBool().withName(Name::EcoMode).withDefault(1.0f).withID(46485) },
+    {ID::EcoMode, pmd().asOnOffBool().withName(Name::EcoMode).withDefault(1.0f).withID(46485) },
 };
 // clang-format on
 

--- a/src/parameter/SynthParam.h
+++ b/src/parameter/SynthParam.h
@@ -375,6 +375,10 @@ struct ObxfParameterFloat : juce::AudioParameterFloat
                       [this](auto v) { return this->valueFromString(v.toStdString()); })),
           meta(md), paramIndex(paramIndexIn)
     {
+        if (!meta.supportsStringConversion)
+        {
+            DBG("Param Setup Error: " << md.name << " does not support string conversion");
+        }
     }
     sst::basic_blocks::params::ParamMetaData meta;
     size_t paramIndex{0};
@@ -382,13 +386,15 @@ struct ObxfParameterFloat : juce::AudioParameterFloat
 
     void setTempoSyncToggleParam(juce::RangedAudioParameter *param) { tempoSyncToggle = param; }
 
+    float denormalizedValue(float value) const
+    {
+        float dv = juce::jmap(value, 0.0f, 1.0f, meta.minVal, meta.maxVal);
+        return dv;
+    }
+
     std::string stringFromValue(float value, int)
     {
-        float denormalizedValue = juce::jmap(value, 0.0f, 1.0f, meta.minVal, meta.maxVal);
-        sst::basic_blocks::params::ParamMetaData::FeatureState fs;
-        fs.isExtended = true;
-
-        auto res = meta.valueToString(denormalizedValue, fs);
+        auto res = meta.valueToString(value);
 
         if (res.has_value())
         {


### PR DESCRIPTION
1. Floats normalize elsewhere so the scale was wrong. Like OSC1 pitch shoed in bitwig as -1000 ... 10000 semitones
2. So normalize in knob not in the param to meet api spec
3. And add formatting methods for loads of params
4. And warn on the ones which don't have them

Closes #305