### PR TITLE
Restore automation->ui channel

### DIFF
--- a/src/PluginEditor.h
+++ b/src/PluginEditor.h
@@ -48,13 +48,14 @@
 
 struct AboutScreen;
 
-using KnobAttachment = Attachment<Knob, void (*)(Knob &, float), float (*)(const Knob &)>;
-using ButtonAttachment =
-    Attachment<ToggleButton, void (*)(ToggleButton &, float), float (*)(const ToggleButton &)>;
+using KnobAttachment = Attachment<Knob, true, void (*)(Knob &, float), float (*)(const Knob &)>;
+using ButtonAttachment = Attachment<ToggleButton, false, void (*)(ToggleButton &, float),
+                                    float (*)(const ToggleButton &)>;
 using ButtonListAttachment =
-    Attachment<ButtonList, void (*)(ButtonList &, float), float (*)(const ButtonList &)>;
-using MultiStateAttachment = Attachment<MultiStateButton, void (*)(MultiStateButton &, float),
-                                        float (*)(const MultiStateButton &)>;
+    Attachment<ButtonList, false, void (*)(ButtonList &, float), float (*)(const ButtonList &)>;
+using MultiStateAttachment =
+    Attachment<MultiStateButton, false, void (*)(MultiStateButton &, float),
+               float (*)(const MultiStateButton &)>;
 
 class ObxfAudioProcessorEditor final : public juce::AudioProcessorEditor,
                                        public juce::AsyncUpdater,

--- a/src/parameter/ParameterAdapter.h
+++ b/src/parameter/ParameterAdapter.h
@@ -114,8 +114,8 @@ class ParameterManagerAdapter
         for (const auto &paramInfo : ParameterList)
         {
             const juce::String &paramId = paramInfo.ID;
-            paramManager.registerParameterCallback(
-                paramId, [this, paramId](const float newValue, bool /*forced*/) {
+            paramManager.addParameterCallback(
+                paramId, "PROGRAM", [this, paramId](const float newValue, bool /*forced*/) {
                     processParameterChange(engine, paramId, newValue);
                     this->programState.updateProgramValue(paramId, newValue);
                 });

--- a/src/parameter/ParameterManager.h
+++ b/src/parameter/ParameterManager.h
@@ -43,7 +43,9 @@ class ParameterManager : public juce::AudioProcessorParameter::Listener
 
     ~ParameterManager() override;
 
-    bool registerParameterCallback(const juce::String &ID, const Callback &cb);
+    bool addParameterCallback(const juce::String &ID, const juce::String &purpose,
+                              const Callback &cb);
+    bool removeParameterCallback(const juce::String &ID, const juce::String &purpose);
 
     void parameterValueChanged(int parameterIndex, float newValue) override;
 
@@ -68,8 +70,15 @@ class ParameterManager : public juce::AudioProcessorParameter::Listener
     FIFO<128> fifo;
     std::vector<ParameterInfo> parameters;
 
-    std::unordered_map<juce::String, Callback> callbacks;
+    std::unordered_map<juce::String, std::unordered_map<juce::String, Callback>> callbacks;
     std::unordered_map<juce::String, juce::RangedAudioParameter *> paramMap;
+
+    /*
+     * Note we have a mutex to lock callbacks but it is almost never contested.
+     * The only reason we need it is if editor closes during VST automation the closing
+     * editor will modify the callback structure to remove its hooks
+     */
+    std::mutex callbackMutex;
 
     JUCE_DECLARE_NON_COPYABLE(ParameterManager)
 


### PR DESCRIPTION
This change upgrades the interaction between automation and the UI in a couple of ways

First it makes the param manager listener a set for multiple purposes so we can have both an engine and a UI listener for a given param

Second it makes the param listener thread safe in the UI side - we are lucky that code was never called!

Third, for knobs, it bundles begin/end edits around the entire drag not around each update

Upshot is: Drag the knob in bitwig and the screen in obxf updates as well as the engine.

CLoses #289