### PR TITLE
Some changes to user dir and save patch

### DIFF
--- a/src/PluginEditor.cpp
+++ b/src/PluginEditor.cpp
@@ -2170,6 +2170,8 @@ void ObxfAudioProcessorEditor::createMenu()
         fileMenu.addItem(MenuAction::CopyPatch, "Copy Patch", true, false);
         fileMenu.addItem(MenuAction::PastePatch, "Paste Patch", enablePasteOption, false);
 
+        fileMenu.addSeparator();
+        fileMenu.addItem(MenuAction::RevealUserDirectory, "Open User Directory", true, false);
         menu->addSubMenu("File", fileMenu);
     }
 
@@ -2407,8 +2409,9 @@ void ObxfAudioProcessorEditor::MenuActionCallback(int action)
 
     if (action == MenuAction::ExportPatch)
     {
-        const auto file = utils.getPresetsFolder();
-        fileChooser = std::make_unique<juce::FileChooser>("Export Preset", file, "*.fxp", true);
+        const auto file = utils.getPresetsFolder().getChildFile(fmt::format(
+            "{}.fxp", processor.getProgramName(processor.getCurrentProgram()).toStdString()));
+        fileChooser = std::make_unique<juce::FileChooser>("Export Patch", file, "*.fxp", true);
         fileChooser->launchAsync(juce::FileBrowserComponent::saveMode |
                                      juce::FileBrowserComponent::canSelectFiles |
                                      juce::FileBrowserComponent::warnAboutOverwriting,
@@ -2482,6 +2485,11 @@ void ObxfAudioProcessorEditor::MenuActionCallback(int action)
         juce::MemoryBlock memoryBlock;
         memoryBlock.fromBase64Encoding(juce::SystemClipboard::getTextFromClipboard());
         processor.loadFromMemoryBlock(memoryBlock);
+    }
+
+    if (action == MenuAction::RevealUserDirectory)
+    {
+        utils.getDocumentFolder().revealToUser();
     }
 
 #if defined(DEBUG) || defined(_DEBUG)

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -26,6 +26,8 @@
 
 Utils::Utils() : configLock("__" JucePlugin_Name "ConfigLock__")
 {
+    createDocumentFolderIfMissing();
+
     juce::PropertiesFile::Options options;
     options.applicationName = JucePlugin_Name;
     options.storageFormat = juce::PropertiesFile::storeAsXML;
@@ -445,3 +447,21 @@ bool Utils::isMemoryBlockAPatch(const juce::MemoryBlock &mb)
 
 void Utils::setDefaultZoomFactor(float f) { config->setValue("default_zoom", f); }
 float Utils::getDefaultZoomFactor() const { return config->getDoubleValue("default_zoom", 1.0); }
+
+void Utils::createDocumentFolderIfMissing()
+{
+    auto docFolder = getDocumentFolder();
+    if (!docFolder.isDirectory())
+    {
+        docFolder.createDirectory();
+    }
+
+    for (const auto &p : {"Patches", "Themes", "Banks"})
+    {
+        auto subFolder = docFolder.getChildFile(p);
+        if (!subFolder.isDirectory())
+        {
+            subFolder.createDirectory();
+        }
+    }
+}

--- a/src/Utils.h
+++ b/src/Utils.h
@@ -66,6 +66,7 @@ class Utils final
     [[nodiscard]] juce::File getFactoryFolder() const;
     [[nodiscard]] juce::File getLocalFactoryFolder() const;
     [[nodiscard]] juce::File getDocumentFolder() const;
+    void createDocumentFolderIfMissing();
     [[nodiscard]] juce::File getMidiFolder() const;
     [[nodiscard]] juce::File getBanksFolder() const;
 

--- a/src/utilities/KeyCommandHandler.h
+++ b/src/utilities/KeyCommandHandler.h
@@ -47,6 +47,8 @@ struct MenuAction
     static constexpr int CopyPatch = 7;
     static constexpr int PastePatch = 8;
 
+    static constexpr int RevealUserDirectory = 9;
+
     static constexpr int Inspector = 100;
 };
 


### PR DESCRIPTION
With the application support etc... storing of themes we dont necessarily have a user documents directory to start the synth which is fine until you go to save an fxp or set a setting.

So this change does a couple of things

1. Creates the user directory on startup if not there
2. Makes export patch use file chooser with the patch name
3. Adds an Open user Directory file menu item so you can get there