### PR TITLE
Install Inno Setup in pipeline

### DIFF
--- a/.github/workflows/build-plugin.yml
+++ b/.github/workflows/build-plugin.yml
@@ -69,6 +69,12 @@ jobs:
         with:
           os: ${{ runner.os }}
 
+      - name: Install Inno Setup
+        if: runner.os == 'Windows'
+        uses: surge-synthesizer/sst-githubactions/install-innosetup@main
+        with:
+          version: 6.5.3
+        
       - uses: apple-actions/import-codesign-certs@v3
         if: runner.os == 'macOS' && github.event_name != 'pull_request'
         with:


### PR DESCRIPTION
We switched from BMP to PNG for our windows installer wizard image. This requires Inno Setup 6.5.2, but the runner has 6.4.0 installed and this was not documented. This makes sure we have the correct version.