### PR TITLE
Inno Setup: Remove non-elevated install until DAWs catch up

### DIFF
--- a/cmake/get_dependencies.cmake
+++ b/cmake/get_dependencies.cmake
@@ -4,7 +4,7 @@
     FetchContent_Declare(
             sst-cmake
             GIT_REPOSITORY https://github.com/surge-synthesizer/sst-cmake.git
-            GIT_TAG        2b4a585aa6d80e8773fcff62831c1b10e2a5d20d
+            GIT_TAG        facd1a1ed0396032702509709a0fdd332445640b
     )
     FetchContent_MakeAvailable(sst-cmake)
 


### PR DESCRIPTION
Windows installer recommends per-user install, which will cause support issues for DAWs that don't support it, DAWs that don't allow adding a plugin path, or just any user expecting it in system directory. Disabling this for now, if we ever re-introduce this we probably want a separate installer