### PR TITLE
Diagnose (for sure) or fix (maybe) a windows fuzzy problem

### DIFF
--- a/src/PluginEditor.cpp
+++ b/src/PluginEditor.cpp
@@ -2812,3 +2812,5 @@ void ObxfAudioProcessorEditor::keyboardFocusMainMenu()
         });
     }
 }
+
+void ObxfAudioProcessorEditor::setScaleFactor(float newScale) { utils.setPluginAPIScale(newScale); }

--- a/src/PluginEditor.cpp
+++ b/src/PluginEditor.cpp
@@ -2813,4 +2813,8 @@ void ObxfAudioProcessorEditor::keyboardFocusMainMenu()
     }
 }
 
-void ObxfAudioProcessorEditor::setScaleFactor(float newScale) { utils.setPluginAPIScale(newScale); }
+void ObxfAudioProcessorEditor::setScaleFactor(float newScale)
+{
+    utils.setPluginAPIScale(newScale);
+    AudioProcessorEditor::setScaleFactor(newScale);
+}

--- a/src/PluginEditor.h
+++ b/src/PluginEditor.h
@@ -144,6 +144,10 @@ class ObxfAudioProcessorEditor final : public juce::AudioProcessorEditor,
 
     juce::PopupMenu createPatchList(juce::PopupMenu &menu, const int itemIdxStart) const;
 
+  public:
+    void setScaleFactor(float newScale) override;
+
+  private:
     void createMenu();
 
     void createMidi(int, juce::PopupMenu &);

--- a/src/Utils.h
+++ b/src/Utils.h
@@ -179,7 +179,11 @@ class Utils final
     juce::File fsPathToJuceFile(const fs::path &) const;
     fs::path juceFileToFsPath(const juce::File &) const;
 
+    void setPluginAPIScale(float s) { pluginApiScale = s; }
+    float getPluginAPIScale() const { return pluginApiScale; }
+
   private:
+    float pluginApiScale{1.f};
     // Config Management
     std::unique_ptr<juce::PropertiesFile> config;
     juce::InterProcessLock configLock;

--- a/src/components/ScalingImageCache.cpp
+++ b/src/components/ScalingImageCache.cpp
@@ -128,7 +128,8 @@ int ScalingImageCache::zoomLevelFor(const std::string &label, const int w, int /
     if (cacheSizes.find(label) == cacheSizes.end())
         return baseZoomLevel;
 
-    const double scale = juce::Desktop::getInstance().getDisplays().getPrimaryDisplay()->scale;
+    double scale = juce::Desktop::getInstance().getDisplays().getPrimaryDisplay()->scale;
+    scale *= utils.getPluginAPIScale();
     auto base = cacheSizes[label];
     const double mu = scale * (static_cast<float>(w) / static_cast<float>(base.first));
 

--- a/src/components/ScalingImageCache.h
+++ b/src/components/ScalingImageCache.h
@@ -30,7 +30,6 @@
 
 struct ScalingImageCache
 {
-
     explicit ScalingImageCache(Utils &utilsRef);
     bool isSVG(const std::string &label);
     int getSvgLayerCount(const std::string &label);

--- a/src/gui/AboutScreen.h
+++ b/src/gui/AboutScreen.h
@@ -242,6 +242,13 @@ struct AboutScreen final : juce::Component
                     5);
         }
 
+        const double scale = juce::Desktop::getInstance().getDisplays().getPrimaryDisplay()->scale;
+        drawTag("Display",
+                fmt::format("{}x{}px, editorScale={}, displayScale={}, pluginScale={}", getWidth(),
+                            getHeight(), editor.impliedScaleFactor(), scale,
+                            editor.utils.getPluginAPIScale()),
+                4);
+
         drawTag("Executable:", sst::plugininfra::paths::sharedLibraryBinaryPath().string(), 2);
         drawTag("Factory Data:",
                 editor.utils.getFactoryFolderInUse().getFullPathName().toStdString(), 1);


### PR DESCRIPTION
This uses the plugin scale as well in the image cache load calculations It should fix a divergence between teh Standalone image selection and the vst3 on windows HDPI.

Windows HDPI is not fun.