### PR TITLE
Fix a knob keyboard error; remove sst-jucegui dep

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -169,8 +169,6 @@ target_link_libraries(OB-Xf PRIVATE
 
     sst-plugininfra::filesystem
     sst-plugininfra
-
-    sst-jucegui
 )
 
 target_compile_definitions(OB-Xf PRIVATE JUCE_VST3_CAN_REPLACE_VST2=0 OBXF_VERSION_STR="${PROJECT_VERSION}")

--- a/cmake/get_dependencies.cmake
+++ b/cmake/get_dependencies.cmake
@@ -80,14 +80,6 @@
     target_include_directories(obxf_version_information PUBLIC ${sstplugininfra_SOURCE_DIR}/include)
     target_compile_definitions(obxf_version_information PUBLIC SST_PLUGININFRA_HAS_VERSION_INFORMATION=1)
 
-
-    FetchContent_Declare(
-            sstjucegui
-            GIT_REPOSITORY https://github.com/surge-synthesizer/sst-jucegui
-            GIT_TAG main
-    )
-    FetchContent_MakeAvailable(sstjucegui)
-
     if(CMAKE_BUILD_TYPE STREQUAL "Debug")
         Include (FetchContent)
         FetchContent_Declare(melatonin_inspector

--- a/src/PluginEditor.cpp
+++ b/src/PluginEditor.cpp
@@ -26,7 +26,7 @@
 #include "components/ScalingImageCache.h"
 #include "gui/AboutScreen.h"
 
-#include "sst/jucegui/accessibility/FocusDebugger.h"
+#include "gui/FocusDebugger.h"
 #include "gui/FocusOrder.h"
 
 static std::weak_ptr<obxf::LookAndFeel> sharedLookAndFeelWeak;
@@ -132,7 +132,7 @@ ObxfAudioProcessorEditor::ObxfAudioProcessorEditor(ObxfAudioProcessor &p)
     inspector->setVisible(false);
 #endif
 
-    focusDebugger = std::make_unique<sst::jucegui::accessibility::FocusDebugger>(*this);
+    focusDebugger = std::make_unique<FocusDebugger>(*this);
     // focusDebugger->setDoFocusDebug(true);
 
     auto sf = utils.getDefaultZoomFactor();

--- a/src/PluginEditor.h
+++ b/src/PluginEditor.h
@@ -46,12 +46,8 @@
 #include "melatonin_inspector/melatonin_inspector.h"
 #endif
 
-namespace sst::jucegui::accessibility
-{
-struct FocusDebugger;
-}
-
 struct AboutScreen;
+struct FocusDebugger;
 
 using KnobAttachment = Attachment<Knob, true, void (*)(Knob &, float), float (*)(const Knob &)>;
 using ButtonAttachment = Attachment<ToggleButton, false, void (*)(ToggleButton &, float),
@@ -199,7 +195,7 @@ class ObxfAudioProcessorEditor final : public juce::AudioProcessorEditor,
     std::unique_ptr<melatonin::Inspector> inspector{};
 #endif
 
-    std::unique_ptr<sst::jucegui::accessibility::FocusDebugger> focusDebugger;
+    std::unique_ptr<FocusDebugger> focusDebugger;
 
     bool backgroundIsSVG{false};
     juce::Image backgroundImage;

--- a/src/gui/FocusDebugger.h
+++ b/src/gui/FocusDebugger.h
@@ -1,0 +1,99 @@
+/*
+ * OB-Xf - a continuation of the last open source version of OB-Xd.
+ *
+ * OB-Xd was originally written by Vadim Filatov, and then a version
+ * was released under the GPL3 at https://github.com/reales/OB-Xd.
+ * Subsequently, the product was continued by DiscoDSP and the copyright
+ * holders as an excellent closed source product. For more info,
+ * see "HISTORY.md" in the root of this repository.
+ *
+ * This repository is a successor to the last open source release,
+ * a version marked as 2.11. Copyright 2013-2025 by the authors
+ * as indicated in the original release, and subsequent authors
+ * per the GitHub transaction log.
+ *
+ * OB-Xf is released under the GNU General Public Licence v3 or later
+ * (GPL-3.0-or-later). The license is found in the file "LICENSE"
+ * in the root of this repository or at:
+ * https://www.gnu.org/licenses/gpl-3.0.en.html
+ *
+ * Source code is available at https://github.com/surge-synthesizer/OB-Xf
+ */
+
+#ifndef OB_XF_SRC_GUI_FOCUSDEBUGGER_H
+#define OB_XF_SRC_GUI_FOCUSDEBUGGER_H
+
+#include <juce_gui_basics/juce_gui_basics.h>
+
+struct FocusDebugger : public juce::FocusChangeListener
+{
+    juce::Component &debugInto;
+    FocusDebugger(juce::Component &c) : debugInto(c)
+    {
+        juce::Desktop::getInstance().addFocusChangeListener(this);
+    }
+    ~FocusDebugger() { juce::Desktop::getInstance().removeFocusChangeListener(this); }
+    void setDoFocusDebug(bool fd)
+    {
+        doFocusDebug = fd;
+        if (doFocusDebug)
+            guaranteeDebugComponent();
+        if (debugComponent)
+            debugComponent->setVisible(fd);
+    }
+
+    bool doFocusDebug{false};
+    void globalFocusChanged(juce::Component *fc) override
+    {
+        if (!doFocusDebug)
+            return;
+
+        if (!fc)
+            return;
+        auto ofc = fc;
+        guaranteeDebugComponent();
+        debugComponent->toFront(false);
+        auto bd = fc->getBounds();
+        fc = fc->getParentComponent();
+        while (fc && fc != &debugInto)
+        {
+            bd += fc->getBounds().getTopLeft();
+            fc = fc->getParentComponent();
+        }
+
+        std::cout << "FD : [" << std::hex << ofc << std::dec << "] " << ofc->getTitle() << " @ "
+                  << bd.toString() << " explicitFocusOrder=" << ofc->getExplicitFocusOrder() << " "
+                  << ofc->getExplicitFocusOrder() << " " << typeid(*ofc).name() << std::endl;
+        debugComponent->setBounds(bd);
+    }
+
+    struct DbgComponent : juce::Component
+    {
+        DbgComponent()
+        {
+            setAccessible(false);
+            setWantsKeyboardFocus(false);
+            setMouseClickGrabsKeyboardFocus(false);
+            setInterceptsMouseClicks(false, false);
+            setTitle("Debug Component");
+        }
+
+        void paint(juce::Graphics &g) override
+        {
+            g.fillAll(juce::Colours::red.withAlpha(0.1f));
+            g.setColour(juce::Colours::red);
+            g.drawRect(getLocalBounds(), 1);
+        }
+    };
+
+    void guaranteeDebugComponent()
+    {
+        if (!debugComponent)
+        {
+            debugComponent = std::make_unique<DbgComponent>();
+            debugInto.addAndMakeVisible(*debugComponent);
+        }
+    }
+    std::unique_ptr<juce::Component> debugComponent;
+};
+#endif // OB_XF_FOCUSDEBUGGER_H

--- a/src/gui/Knob.h
+++ b/src/gui/Knob.h
@@ -69,6 +69,7 @@ class Knob final : public juce::Slider, public juce::ActionBroadcaster
             textEditor->setIndents(2, 0);
             textEditor->setCaretVisible(true);
             textEditor->setReadOnly(false);
+            textEditor->setTitle(k->parameter->getName(128));
 
             addAndMakeVisible(*textEditor);
         }
@@ -148,10 +149,21 @@ class Knob final : public juce::Slider, public juce::ActionBroadcaster
                 knob->setValue(juce::jlimit(knob->getMinimum(), knob->getMaximum(), v),
                                juce::sendNotificationAsync);
                 triggerMenuItem();
+                juce::MessageManager::callAsync([w = juce::Component::SafePointer(knob)]() {
+                    if (w)
+                        w->grabKeyboardFocus();
+                });
             }
         }
 
-        void textEditorEscapeKeyPressed(juce::TextEditor &) override { triggerMenuItem(); }
+        void textEditorEscapeKeyPressed(juce::TextEditor &) override
+        {
+            triggerMenuItem();
+            juce::MessageManager::callAsync([w = juce::Component::SafePointer(knob)]() {
+                if (w)
+                    w->grabKeyboardFocus();
+            });
+        }
     };
 
   public:
@@ -375,7 +387,7 @@ class Knob final : public juce::Slider, public juce::ActionBroadcaster
   public:
     bool keyPressed(const juce::KeyPress &e) override
     {
-        if (e.getModifiers().isShiftDown() || e.getKeyCode() == juce::KeyPress::F10Key)
+        if (e.getModifiers().isShiftDown() && e.getKeyCode() == juce::KeyPress::F10Key)
         {
             showPopupMenu();
             return true;


### PR DESCRIPTION
1. Fix a knob keyboard error where I had shift || F10 not shift &&
2. Have knob menu handler accessibility have name in title field and return to knob on enter
3. Copy the sst-jucegui focus debugger in since it was the only bit of sstjg we were using; break the sstjg dep