### PR TITLE
Be more parsimonious in our use of updateHostDisplay

### DIFF
--- a/src/PluginEditor.cpp
+++ b/src/PluginEditor.cpp
@@ -1744,7 +1744,7 @@ void ObxfAudioProcessorEditor::idle()
     {
         countTimer = 0;
         needNotifyToHost = false;
-        processor.updateHostDisplay();
+        processor.updateHostDisplay(juce::AudioProcessor::ChangeDetails().withProgramChanged(true));
 
         if (patchNumberMenu)
         {

--- a/src/PluginProcessor.h
+++ b/src/PluginProcessor.h
@@ -38,6 +38,32 @@
 #include "Utils.h"
 #include "StateManager.h"
 
+#if BACONPAUL_IS_DEBUGGING_IN_LOGIC
+// so please leave this in until we are sure we have it all OK?
+#include <fstream>
+#include <stdio.h>
+#include <cstdlib>
+#include <execinfo.h>
+
+extern std::ofstream logHack;
+#define LOGH(...)                                                                                  \
+    logHack << __FILE__ << ":" << __LINE__ << " " << __TIME__ << " " << __VA_ARGS__ << std::flush  \
+            << std::endl;
+
+inline void LOGST()
+{
+    void *callstack[128];
+    int i, frames = backtrace(callstack, 128);
+    char **strs = backtrace_symbols(callstack, frames);
+
+    for (i = 1; i < frames && i < 6; ++i)
+    {
+        LOGH("  [" << i << "]: " << strs[i]);
+    }
+    free(strs);
+}
+#endif
+
 class ObxfAudioProcessor final : public juce::AudioProcessor,
                                  public IParameterState,
                                  public IProgramState


### PR DESCRIPTION
updateHostDisplay by default udpates everything - latency param names and values programs and so on. We were calling it willy nilly with the default. This over-stressed all daws but in Logic it meant the setCurrentProgram order of operations would cause a rescan of params without them having been host updated and that would reset the entire thing wrongly. Bad bad.

So change it so that doesn't happen and low logic works great!

Addresses #333