### PR TITLE
ClipRect for Label Traversal always outside

### DIFF
--- a/src/gui/Label.h
+++ b/src/gui/Label.h
@@ -86,7 +86,7 @@ class Label final : public juce::Drawable
                                                                               currentFrame);
 
             juce::Graphics::ScopedSaveState ss(g);
-            g.reduceClipRegion(getLocalBounds().withHeight(scale * frameHeight));
+            g.reduceClipRegion(getLocalBounds().withHeight(std::ceil(scale * frameHeight)));
             svgi->draw(g, 1.f, tf);
         }
         else


### PR DESCRIPTION
so ceil vs round. Stops truncation on vector label assets