### PR TITLE
Fix some initial zoom problems

### DIFF
--- a/src/PluginEditor.h
+++ b/src/PluginEditor.h
@@ -110,6 +110,8 @@ class ObxfAudioProcessorEditor final : public juce::AudioProcessorEditor,
 
     void actionListenerCallback(const juce::String &message) override;
 
+    void parentHierarchyChanged() override;
+
   private:
     juce::Rectangle<int> transformBounds(int x, int y, int w, int h) const;
 
@@ -179,10 +181,6 @@ class ObxfAudioProcessorEditor final : public juce::AudioProcessorEditor,
 
   public:
     void idle();
-    // The various caches are a bit off with zoom in constructor
-    // so just call resize again first time round the idle loop if
-    // this is set. Or remove this and fix that bug I couldn't find.
-    bool resizeOnNextIdle = false;
 
   private:
     std::unique_ptr<juce::Timer> idleTimer;

--- a/src/gui/ButtonList.h
+++ b/src/gui/ButtonList.h
@@ -27,6 +27,7 @@
 
 #include "../src/engine/SynthEngine.h"
 #include "../components/ScalingImageCache.h"
+#include "HasScaleFactor.h"
 
 class ButtonListLookAndFeel final : public juce::LookAndFeel_V4
 {
@@ -42,7 +43,7 @@ class ButtonListLookAndFeel final : public juce::LookAndFeel_V4
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(ButtonListLookAndFeel)
 };
 
-class ButtonList final : public juce::ComboBox
+class ButtonList final : public juce::ComboBox, public HasScaleFactor
 {
     juce::String img_name;
     ScalingImageCache &imageCache;
@@ -61,7 +62,7 @@ class ButtonList final : public juce::ComboBox
 
     ~ButtonList() override { setLookAndFeel(nullptr); }
 
-    void scaleFactorChanged()
+    void scaleFactorChanged() override
     {
         if (imageCache.isSVG(img_name.toStdString()))
         {

--- a/src/gui/HasScaleFactor.h
+++ b/src/gui/HasScaleFactor.h
@@ -1,0 +1,32 @@
+/*
+ * OB-Xf - a continuation of the last open source version of OB-Xd.
+ *
+ * OB-Xd was originally written by Vadim Filatov, and then a version
+ * was released under the GPL3 at https://github.com/reales/OB-Xd.
+ * Subsequently, the product was continued by DiscoDSP and the copyright
+ * holders as an excellent closed source product. For more info,
+ * see "HISTORY.md" in the root of this repository.
+ *
+ * This repository is a successor to the last open source release,
+ * a version marked as 2.11. Copyright 2013-2025 by the authors
+ * as indicated in the original release, and subsequent authors
+ * per the GitHub transaction log.
+ *
+ * OB-Xf is released under the GNU General Public Licence v3 or later
+ * (GPL-3.0-or-later). The license is found in the file "LICENSE"
+ * in the root of this repository or at:
+ * https://www.gnu.org/licenses/gpl-3.0.en.html
+ *
+ * Source code is available at https://github.com/surge-synthesizer/OB-Xf
+ */
+
+#ifndef OB_XF_SRC_GUI_HASSCALEFACTOR_H
+#define OB_XF_SRC_GUI_HASSCALEFACTOR_H
+
+struct HasScaleFactor
+{
+    virtual ~HasScaleFactor() = default;
+    virtual void scaleFactorChanged() = 0;
+};
+
+#endif // OB_XF_HASSCALEFACTOR_H

--- a/src/gui/ImageMenu.h
+++ b/src/gui/ImageMenu.h
@@ -27,8 +27,9 @@
 
 #include "../src/engine/SynthEngine.h"
 #include "../components/ScalingImageCache.h"
+#include "HasScaleFactor.h"
 
-class ImageMenu : public juce::ImageButton
+class ImageMenu : public juce::ImageButton, public HasScaleFactor
 {
     juce::String img_name;
     bool isSVG{false};
@@ -42,7 +43,7 @@ class ImageMenu : public juce::ImageButton
         Component::setVisible(true);
     }
 
-    void scaleFactorChanged()
+    void scaleFactorChanged() override
     {
         if (imageCache.isSVG(img_name.toStdString()))
         {

--- a/src/gui/Knob.h
+++ b/src/gui/Knob.h
@@ -27,6 +27,7 @@
 
 #include "../src/engine/SynthEngine.h"
 #include "../components/ScalingImageCache.h"
+#include "HasScaleFactor.h"
 
 class ObxfAudioProcessor;
 
@@ -51,7 +52,7 @@ class KnobLookAndFeel final : public juce::LookAndFeel_V4
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(KnobLookAndFeel)
 };
 
-class Knob final : public juce::Slider, public juce::ActionBroadcaster
+class Knob final : public juce::Slider, public juce::ActionBroadcaster, public HasScaleFactor
 {
     juce::String img_name;
     ScalingImageCache &imageCache;
@@ -199,7 +200,7 @@ class Knob final : public juce::Slider, public juce::ActionBroadcaster
             return std::nullopt;
     }
 
-    void scaleFactorChanged()
+    void scaleFactorChanged() override
     {
         isSVG = imageCache.isSVG(img_name.toStdString());
         if (!isSVG)

--- a/src/gui/Label.h
+++ b/src/gui/Label.h
@@ -25,8 +25,9 @@
 
 #include <juce_gui_basics/juce_gui_basics.h>
 #include "../components/ScalingImageCache.h"
+#include "HasScaleFactor.h"
 
-class Label final : public juce::Drawable
+class Label final : public juce::Component, public HasScaleFactor
 {
   public:
     Label(const juce::String &name, int fh, ScalingImageCache &cache)
@@ -48,7 +49,7 @@ class Label final : public juce::Drawable
         }
     }
 
-    void scaleFactorChanged()
+    void scaleFactorChanged() override
     {
         if (imageCache.isSVG(img_name.toStdString()))
         {
@@ -110,31 +111,12 @@ class Label final : public juce::Drawable
         }
     }
 
-    juce::Rectangle<float> getDrawableBounds() const override { return bounds.toFloat(); }
-
-    void setDrawableBounds(juce::Rectangle<int> newBounds) { bounds = newBounds; }
-
-    juce::Path getOutlineAsPath() const override
-    {
-        juce::Path path;
-        path.addRectangle(bounds);
-        return path;
-    }
-
-    std::unique_ptr<juce::Drawable> createCopy() const override
-    {
-        auto copy = std::make_unique<Label>(img_name, frameHeight, imageCache);
-        copy->setCurrentFrame(currentFrame);
-        return copy;
-    }
-
   private:
     juce::String img_name;
     juce::Image label;
     int frameHeight;
     int currentFrame;
     int totalFrames;
-    juce::Rectangle<int> bounds;
     ScalingImageCache &imageCache;
     bool isSVG{false};
 

--- a/src/gui/MultiStateButton.h
+++ b/src/gui/MultiStateButton.h
@@ -27,8 +27,9 @@
 
 #include "../src/engine/SynthEngine.h"
 #include "../components/ScalingImageCache.h"
+#include "HasScaleFactor.h"
 
-class MultiStateButton final : public juce::Slider
+class MultiStateButton final : public juce::Slider, public HasScaleFactor
 {
     juce::String img_name;
     ScalingImageCache &imageCache;
@@ -60,7 +61,7 @@ class MultiStateButton final : public juce::Slider
         setRange(0.f, 1.f, stepSize);
     }
 
-    void scaleFactorChanged()
+    void scaleFactorChanged() override
     {
         if (imageCache.isSVG(img_name.toStdString()))
         {

--- a/src/gui/ToggleButton.h
+++ b/src/gui/ToggleButton.h
@@ -27,8 +27,9 @@
 
 #include "../src/engine/SynthEngine.h"
 #include "../components/ScalingImageCache.h"
+#include "HasScaleFactor.h"
 
-class ToggleButton final : public juce::ImageButton
+class ToggleButton final : public juce::ImageButton, public HasScaleFactor
 {
     juce::String img_name;
     ScalingImageCache &imageCache;
@@ -62,7 +63,7 @@ class ToggleButton final : public juce::ImageButton
         setClickingTogglesState(true);
     }
 
-    void scaleFactorChanged()
+    void scaleFactorChanged() override
     {
         if (imageCache.isSVG(img_name.toStdString()))
         {


### PR DESCRIPTION
Initial zoom of non-100% didn't really work and I had the odd delayed resized call in the idle loop to work around it. Well I found out the problem. Basically

1. Want to force a call to scaleFactorChanged and
2. Label was screwed up generlally

Fix 1 by adding a HasScaleFactor interface we can cast to to force post resize in constructor

Fix 2 by moving Label for a Drawable to a Component. There was no need for it to ever implement the Drawable API.