### PR TITLE
Restore the resize on idle

### DIFF
--- a/src/PluginEditor.cpp
+++ b/src/PluginEditor.cpp
@@ -156,6 +156,7 @@ ObxfAudioProcessorEditor::ObxfAudioProcessorEditor(ObxfAudioProcessor &p)
             hcf->scaleFactorChanged();
         }
     }
+    resizeOnNextIdle = 3;
 }
 
 void ObxfAudioProcessorEditor::parentHierarchyChanged()
@@ -173,7 +174,10 @@ void ObxfAudioProcessorEditor::parentHierarchyChanged()
         }
     }
 #endif
-    resized();
+    if (isShowing() && isVisible())
+    {
+        resized();
+    }
 }
 
 void ObxfAudioProcessorEditor::resized()
@@ -1775,6 +1779,23 @@ void ObxfAudioProcessorEditor::idle()
 
     countTimer++;
 
+    if (isShowing() && isVisible() && resizeOnNextIdle >= 0)
+    {
+        resizeOnNextIdle--;
+        if (resizeOnNextIdle == 0)
+        {
+            std::cout << "RESIZE ON NEXT IDLE " << getWidth() << " " << getHeight() << std::endl;
+            resized();
+            // including forcing the larger assets to load if needed
+            for (auto &[n, c] : componentMap)
+            {
+                if (auto hcf = dynamic_cast<HasScaleFactor *>(c))
+                {
+                    hcf->scaleFactorChanged();
+                }
+            }
+        }
+    }
     if (countTimer == 4 && needNotifyToHost)
     {
         countTimer = 0;

--- a/src/PluginEditor.h
+++ b/src/PluginEditor.h
@@ -105,6 +105,7 @@ class ObxfAudioProcessorEditor final : public juce::AudioProcessorEditor,
     void MenuActionCallback(int action);
 
     void resized() override;
+    int32_t resizeOnNextIdle{-1}; // basically an idle countdown
 
     bool isHighResolutionDisplay() const { return utils.getPixelScaleFactor() > 1.0; }
 


### PR DESCRIPTION
Something is making VST3 on windows high def lose a resize message. I have a theory that the queue gets flooded while loading assets and one gets lost, or a resize gets called before a size is set, or some such. But I can't pin it down. This restores the resize on idle hammer.