### PR TITLE
Implement CC #0 (Bank Select MSB) to work with Program Change

### DIFF
--- a/src/midi/MidiHandler.h
+++ b/src/midi/MidiHandler.h
@@ -74,6 +74,7 @@ class MidiHandler
     int lastMovedController{0};
     std::atomic<int> lastUsedParameter{0};
     int midiEventPos{0};
+    uint8_t bankSelectMSB{0};
 
     juce::String currentMidiPath;
 };


### PR DESCRIPTION
Now you can switch between patches 1-128 and 129-256!

TODO: Patch number display doesn't update on receiving Program Change.

Also disallow using CCs 0, 64, 74, 120 and 123 for MIDI learn.