### PR TITLE
Temporarily turn off windows HDPI plugin support

### DIFF
--- a/resources/NightlyBlurb.md
+++ b/resources/NightlyBlurb.md
@@ -4,6 +4,8 @@ This page contains a copy of OB-Xf built from the head of the repository. We con
 
 To install on your system, download the appropriate installer (dmg, exe, deb) and run it.
 
+Notice to windows HDPI users. We are chasing a crashing bug with the bitmap skin in windows HDPI in plugins, so this build has HDPI off for the VST3 and CLAP, and the bitmap theme may be fuzzy.
+
 We also provide a ZIP archive for Windows and Linux, but when using these you are responsible for placing the assets from the assets.zip file to the right location on your system. If you take this route and get it wrong, run the standalone and it will show you where it attempted to look for assets.
 
 We have a few items left to do between beta and a 1.0, including finishing MIDI learn UI/UX and resolving other bugs in the beta period, but the synth is stable now.

--- a/src/PluginEditor.cpp
+++ b/src/PluginEditor.cpp
@@ -2936,11 +2936,13 @@ void ObxfAudioProcessorEditor::keyboardFocusMainMenu()
     }
 }
 
+#if SUPPORT_PLUGIN_SCALE
 void ObxfAudioProcessorEditor::setScaleFactor(float newScale)
 {
     utils.setPluginAPIScale(newScale);
     AudioProcessorEditor::setScaleFactor(newScale);
 }
+#endif
 
 void ObxfAudioProcessorEditor::randomizeCallback()
 {

--- a/src/PluginEditor.h
+++ b/src/PluginEditor.h
@@ -144,7 +144,9 @@ class ObxfAudioProcessorEditor final : public juce::AudioProcessorEditor,
     juce::PopupMenu createPatchList(juce::PopupMenu &menu, const int itemIdxStart) const;
 
   public:
+#if SUPPORT_PLUGIN_SCALE
     void setScaleFactor(float newScale) override;
+#endif
 
   private:
     void createMenu();

--- a/src/Utils.h
+++ b/src/Utils.h
@@ -63,7 +63,7 @@ class Utils final
         EMBEDDED = 3
     };
 
-    const juce::File embeddedThemeSentinel{"/embedded-theme/Default (Embedded)"};
+    const juce::File embeddedThemeSentinel{"/embedded-theme/Default (Vector BuiltIn)"};
 
     // File System Methods
     [[nodiscard]] juce::File getFactoryFolderInUse() const;


### PR DESCRIPTION
Windows HDPI plugin support is causing crashes and we dont know why. To keep the beta going, turn it off while we debug and update the Nightly Blurb to say so