### PR TITLE
Temporary cleanup of midi file stuff

### DIFF
--- a/src/PluginEditor.cpp
+++ b/src/PluginEditor.cpp
@@ -1784,7 +1784,6 @@ void ObxfAudioProcessorEditor::idle()
         resizeOnNextIdle--;
         if (resizeOnNextIdle == 0)
         {
-            std::cout << "RESIZE ON NEXT IDLE " << getWidth() << " " << getHeight() << std::endl;
             resized();
             // including forcing the larger assets to load if needed
             for (auto &[n, c] : componentMap)
@@ -1795,6 +1794,15 @@ void ObxfAudioProcessorEditor::idle()
                 }
             }
         }
+    }
+
+    if (processor.getParamAdapter().midiLearnChanged)
+    {
+        processor.getParamAdapter().midiLearnChanged = false;
+
+        juce::File midi_file =
+            utils.getMidiFolderFor(Utils::LocationType::USER).getChildFile("current-session.xml");
+        processor.getMidiHandler().saveBindingsTo(midi_file);
     }
     if (countTimer == 4 && needNotifyToHost)
     {

--- a/src/PluginProcessor.h
+++ b/src/PluginProcessor.h
@@ -226,6 +226,8 @@ class ObxfAudioProcessor final : public juce::AudioProcessor,
     } uiState;
     void updateUIState();
 
+    MidiHandler &getMidiHandler() { return midiHandler; }
+
   private:
     std::atomic<bool> isHostAutomatedChange{};
     SynthEngine synth;

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -527,7 +527,7 @@ void Utils::createDocumentFolderIfMissing()
         docFolder.createDirectory();
     }
 
-    for (const auto &p : {"Patches", "Themes", "Banks"})
+    for (const auto &p : {"Patches", "Themes", "Banks", "MIDI"})
     {
         auto subFolder = docFolder.getChildFile(p);
         if (!subFolder.isDirectory())

--- a/src/engine/MidiMap.h
+++ b/src/engine/MidiMap.h
@@ -53,11 +53,12 @@ class MidiMap
 
     void setXml(juce::XmlElement &xml)
     {
-        for (auto c : controllers)
+        for (int idx = 0; idx < NUM_MIDI_CC; idx++)
         {
+            auto c = controllers[idx];
             if (c > -1)
             {
-                xml.setAttribute("CC" + juce::String(c), getTag(c));
+                xml.setAttribute("CC" + juce::String(idx), c);
             }
         }
     }
@@ -80,13 +81,17 @@ class MidiMap
 
     void getXml(juce::XmlElement &xml)
     {
-        for (auto &c : controllers)
+        for (int idx = 0; idx < NUM_MIDI_CC; idx++)
         {
-            juce::String tmp = xml.getStringAttribute("CC" + juce::String(c), "undefined");
+            juce::String tmp = xml.getStringAttribute("CC" + juce::String(idx));
 
-            if (tmp != "undefined")
+            if (!tmp.isEmpty())
             {
-                c = getParaId(tmp);
+                controllers[idx] = tmp.getIntValue();
+            }
+            else
+            {
+                controllers[idx] = -1;
             }
         }
     }
@@ -118,15 +123,12 @@ class MidiMap
         controllers[midiCC] = idx_para;
     }
 
-    void saveFile(juce::File &xml)
+    void saveFile(const juce::File &xml)
     {
         juce::XmlElement ele("Data");
         this->setXml(ele);
 
-        if (auto outStream = xml.createOutputStream())
-        {
-            ele.writeTo(*outStream);
-        }
+        ele.writeTo(xml);
     }
 };
 

--- a/src/midi/MidiHandler.h
+++ b/src/midi/MidiHandler.h
@@ -23,6 +23,8 @@
 #ifndef OBXF_SRC_MIDI_MIDIHANDLER_H
 #define OBXF_SRC_MIDI_MIDIHANDLER_H
 
+#include "MidiMap.h"
+
 #include <juce_audio_basics/juce_audio_basics.h>
 
 #include "Utils.h"
@@ -60,6 +62,8 @@ class MidiHandler
     std::function<void(int)> onProgramChangeCallback;
 
     int getLastUsedParameter() const { return lastUsedParameter; }
+
+    void saveBindingsTo(const juce::File &f) const { bindings.saveFile(f); }
 
   private:
     Utils &utils;

--- a/src/parameter/ParameterAdapter.h
+++ b/src/parameter/ParameterAdapter.h
@@ -47,6 +47,7 @@ class ParameterManagerAdapter
 {
   public:
     ValueAttachment<bool> midiLearnAttachment{};
+    std::atomic<bool> midiLearnChanged{false};
 
     ParameterManagerAdapter(IParameterState &paramState, IProgramState &progState,
                             juce::AudioProcessor &processor, SynthEngine &synth)


### PR DESCRIPTION
1. MidiMap to/from file and to/from xml just didn't work. Now it does
2. We saved stuff in the audio thread. Push it to the idle
3. Have a temporary feature that we save the current midi map always to documents/MIDI/current-session.xml but this will obviously need reworking
4. Doon't touch the goofy Default and Config stuff that much otherwise. Looks like it neds some focus

But with this I can at least get a midi learn which sticks so I can test lags.