### PR TITLE
Implement DAW Extra State, currently with just a test

### DIFF
--- a/src/PluginProcessor.cpp
+++ b/src/PluginProcessor.cpp
@@ -288,12 +288,14 @@ void ObxfAudioProcessor::onProgramChange(const int programNumber)
 
 void ObxfAudioProcessor::getStateInformation(juce::MemoryBlock &destData)
 {
+    state->collectDAWExtraStateFromInstance();
     state->getStateInformation(destData);
 }
 
 void ObxfAudioProcessor::setStateInformation(const void *data, const int sizeInBytes)
 {
     state->setStateInformation(data, sizeInBytes, true);
+    state->applyDAWExtraStateToInstance();
 }
 
 void ObxfAudioProcessor::initializeMidiCallbacks()

--- a/src/state/StateManager.h
+++ b/src/state/StateManager.h
@@ -57,7 +57,42 @@ class StateManager final : public juce::ChangeBroadcaster
 
     void setCurrentProgramStateInformation(const void *data, int sizeInBytes);
 
+    /*
+     * The DAW Extra State mechanism works as follows
+     *
+     * - On saving to the DAW (Processor:;getStateInformation) before
+     * the stream we call collectDAWExtraStateFromInstance before stream.
+     * That will let you put whatever you want on the instance here.
+     *
+     * Then in the resulting XML we put the result of dawExtraState::toElement
+     *
+     * On unstream it is the opposite (xml -> fromElement and then after unstream
+     * we do a applyDAWExtraStateToInstance)
+     *
+     * that means if you add something to DES you ahve five steps
+     *
+     * - add a data member to DAWExtraState
+     * - Populate it from the processor * in collect
+     * - stream it in to
+     * - unstream it in from - but unstream it onto the
+     *   daw extra state object
+     * - apply the dawExtraState new member to a provcessor in apply
+     *
+     * Basically the DAWExtraState object acts as a little buffer of
+     * stuff we want to collect which is not patch stored.
+     */
+    void collectDAWExtraStateFromInstance();
+    void applyDAWExtraStateToInstance();
+
   private:
+    struct DAWExtraState
+    {
+        static constexpr int desVersion{1};
+        uint32_t aTestNumber;
+
+        std::unique_ptr<juce::XmlElement> toElement() const;
+        void fromElement(const juce::XmlElement *e);
+    } dawExtraState;
     ObxfAudioProcessor *audioProcessor{nullptr};
 };
 


### PR DESCRIPTION
Implement a DAW Extra State mechanism to store additional things we want in the patch.

Currently we just store a truncated version of the microseconds since epoch when we streamed. Remove that obviously as we populate in the future.