### PR TITLE
MidiCC Application Overhaul; Lags and Transforms

### DIFF
--- a/src/PluginProcessor.cpp
+++ b/src/PluginProcessor.cpp
@@ -71,6 +71,7 @@ void ObxfAudioProcessor::prepareToPlay(const double sampleRate, const int /*samp
     paramAdapter->updateParameters(true);
 
     synth.setSampleRate(static_cast<float>(sampleRate));
+    midiHandler.setSampleRate(sampleRate);
 }
 
 void ObxfAudioProcessor::processBlock(juce::AudioBuffer<float> &buffer,
@@ -140,6 +141,8 @@ void ObxfAudioProcessor::processBlock(juce::AudioBuffer<float> &buffer,
         {
             midiHandler.processMidiPerSample(&it, midiMessages, samplePos);
         }
+        midiHandler.processLags();
+
         synth.processSample(channelData1 + samplePos, channelData2 + samplePos);
         ++samplePos;
     }
@@ -288,6 +291,7 @@ void ObxfAudioProcessor::onProgramChange(const int programNumber)
 
 void ObxfAudioProcessor::getStateInformation(juce::MemoryBlock &destData)
 {
+    midiHandler.snapLags();
     state->collectDAWExtraStateFromInstance();
     state->getStateInformation(destData);
 }

--- a/src/midi/MidiHandler.h
+++ b/src/midi/MidiHandler.h
@@ -37,6 +37,9 @@ class MidiHandler
 {
   public:
     MidiHandler(SynthEngine &s, MidiMap &b, ParameterManagerAdapter &pm, Utils &utils);
+    ~MidiHandler();
+
+    void setSampleRate(double sampleRate); // for midi cc smoothing
 
     void prepareToPlay();
 
@@ -68,6 +71,9 @@ class MidiHandler
     MidiMap &getMidiMap() { return bindings; }
     const MidiMap &getMidiMap() const { return bindings; }
 
+    void snapLags();
+    void processLags();
+
   private:
     Utils &utils;
     SynthEngine &synth;
@@ -84,6 +90,11 @@ class MidiHandler
     uint8_t bankSelectMSB{0};
 
     juce::String currentMidiPath;
+
+    struct LagHandler;
+    std::unique_ptr<LagHandler> lagHandler;
+    size_t lagPos{0};
+    friend struct LagHandler;
 };
 
 #endif // OBXF_SRC_MIDI_MIDIHANDLER_H

--- a/src/parameter/ParameterManager.cpp
+++ b/src/parameter/ParameterManager.cpp
@@ -180,6 +180,13 @@ void ParameterManager::updateParameters(const bool force)
 #endif
 }
 
+void ParameterManager::forceSingleParameterCallback(const juce::String &paramID, float newValue)
+{
+    if (auto it = callbacks.find(paramID); it != callbacks.end())
+        for (auto &[_, cb] : it->second)
+            cb(newValue, true);
+}
+
 void ParameterManager::clearParameterQueue() { fifo.clear(); }
 
 const std::vector<ParameterInfo> &ParameterManager::getParameters() const { return parameters; }

--- a/src/parameter/ParameterManager.h
+++ b/src/parameter/ParameterManager.h
@@ -22,6 +22,7 @@
 
 #ifndef OBXF_SRC_PARAMETER_PARAMETERMANAGER_H
 #define OBXF_SRC_PARAMETER_PARAMETERMANAGER_H
+#define OBXF_SRC_PARAupdaMETER_PARAMETERMANAGER_H
 
 #include <juce_audio_basics/juce_audio_basics.h>
 #include <juce_audio_processors/juce_audio_processors.h>
@@ -56,6 +57,9 @@ class ParameterManager : public juce::AudioProcessorParameter::Listener
     void clearFiFO() { fifo.clear(); }
 
     void updateParameters(bool force = false);
+
+    // audio thread only please for this one
+    void forceSingleParameterCallback(const juce::String &paramID, float newValue);
 
     void clearParameterQueue();
 


### PR DESCRIPTION
This completes the overhaul of how we apply midiCC at learn points. It does a few things

1. It adds a linear interp and makes it way closer to sample accurate as a result to smooth the inbound midi.
2. It adds a concept of "per target transform" in midicc
3. It adds the following transforms
   - Regular
   - Bipolar symmetric: 0,1 collapse to a same value, 64 to mid
   - Pitch: basically if applied to pitch then 16 ... 110 maps to semis
   - Stepped: Makes sure we use uniform step size midi space for integer params

Lots of testing to do here, but a good checkpoint