### PR TITLE
Fix two problems mis-activating LFO on Init

### DIFF
--- a/src/engine/Parameters.h
+++ b/src/engine/Parameters.h
@@ -36,7 +36,9 @@ class Parameters
     {
         values.clear();
         for (const auto &param : ParameterList)
+        {
             values[param.ID] = param.meta.naturalToNormalized01(param.meta.defaultVal);
+        }
     }
 
     float getValueById(const juce::String &id) const

--- a/src/engine/SynthEngine.h
+++ b/src/engine/SynthEngine.h
@@ -49,7 +49,12 @@ class SynthEngine
 
     // clever trick to avoid nested ternary, which provides 0.f -> 0.f, 0.5f -> 1.f, 1.f -> -1.f
     // we use it for inverting LFO modulations per target via tri-state buttons
-    float remapZeroHalfOneToZeroOneMinusOne(float x) { return (5 * x) - (6 * x * x); }
+    float remapZeroHalfOneToZeroOneMinusOne(float x)
+    {
+        auto res = (5 * x) - (6 * x * x);
+        // if x is, like, 0.05 from a vst edge  will blow out so round to restore ternary
+        return std::round(res);
+    }
 
     // JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (SynthEngine)
 


### PR DESCRIPTION
The init patch seemed to have the LFO activated. There were two reasons for this

1. The clever '0/0.5/1 to 0/1/-1' didn't work if the value input was not exactly those. So things like vst3 mod and so forth would blow up this strategy. Fix with a round.
2. The sst-basic-blocks normalize value on an int used by default the silly surge convention of +0.05 and *0.9 so the inir value of LFO1ToPitch was 0 (int) but 0.05 (float normalized). Which combined with above bug went blammo. Fix this by making basic blocks have an off-by-default argument to use the crappy surge normalization, since we dont use it in surge.

Closes #425