### PR TITLE
Patch Bank Restore/Save gestures

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -136,6 +136,7 @@ target_sources(OB-Xf PRIVATE
     src/state/StateManager.cpp
     src/midi/MidiHandler.cpp
     src/parameter/ParameterManager.cpp
+    src/parameter/ParameterAdapter.cpp
     src/components/ScalingImageCache.cpp
 )
 

--- a/src/PluginEditor.cpp
+++ b/src/PluginEditor.cpp
@@ -1391,14 +1391,22 @@ void ObxfAudioProcessorEditor::createComponentsFromXml(const juce::XmlElement *d
             savePatchButton = addButton(x, y, w, h, juce::String{}, Name::SavePatch,
                                         useAssetOrDefault(pic, "button-clear-red"));
             componentMap[name] = savePatchButton.get();
-            // TODO onClick lambda
+            savePatchButton->onClick = [w = juce::Component::SafePointer(this)]() {
+                if (!w)
+                    return;
+                w->processor.saveCurrentProgramAsOriginalState();
+            };
         }
         if (name == "origPatchButton")
         {
             origPatchButton = addButton(x, y, w, h, juce::String{}, Name::OrigPatch,
                                         useAssetOrDefault(pic, "button"));
             componentMap[name] = origPatchButton.get();
-            // TODO onClick lambda
+            origPatchButton->onClick = [w = juce::Component::SafePointer(this)]() {
+                if (!w)
+                    return;
+                w->processor.restoreCurrentProgramToOriginalState();
+            };
         }
 
         if (name == "initPatchButton")
@@ -1992,6 +2000,17 @@ void ObxfAudioProcessorEditor::idle()
     {
         patchNameLabel->setText(processor.getProgramName(processor.getCurrentProgram()),
                                 juce::dontSendNotification);
+    }
+
+    if (origPatchButton)
+    {
+        bool isDirty = processor.uiState.currentProgramDirty;
+        auto val = origPatchButton->getToggleState();
+        if (val != isDirty)
+        {
+            origPatchButton->setToggleState(isDirty, juce::dontSendNotification);
+        }
+        origPatchButton->setEnabled(isDirty);
     }
 }
 

--- a/src/PluginProcessor.h
+++ b/src/PluginProcessor.h
@@ -216,6 +216,9 @@ class ObxfAudioProcessor final : public juce::AudioProcessor,
         // Editor write Audio read
         std::atomic<bool> editorAttached;
 
+        // Current program dirty
+        std::atomic<bool> currentProgramDirty;
+
         // Audio write editor read
         std::array<std::atomic<float>, MAX_VOICES> voiceStatusValue;
 
@@ -225,6 +228,10 @@ class ObxfAudioProcessor final : public juce::AudioProcessor,
         static constexpr int32_t updateInterval{500};
     } uiState;
     void updateUIState();
+
+    void setCurrentProgramDirtyState(bool isDirty);
+    void restoreCurrentProgramToOriginalState();
+    void saveCurrentProgramAsOriginalState();
 
     MidiHandler &getMidiHandler() { return midiHandler; }
 

--- a/src/engine/Bank.h
+++ b/src/engine/Bank.h
@@ -31,20 +31,34 @@
 class Bank
 {
   public:
-    Parameters programs[MAX_PROGRAMS];
+    Program programs[MAX_PROGRAMS], originalPrograms[MAX_PROGRAMS];
     std::atomic<int> currentProgram{0};
+    std::array<bool, MAX_PROGRAMS> programDirty{};
 
     Bank() = default;
 
-    Parameters &getCurrentProgram()
+    Program &getCurrentProgram()
     {
         assert(hasCurrentProgram());
         return programs[currentProgram.load()];
     }
-    const Parameters &getCurrentProgram() const
+    const Program &getCurrentProgram() const
     {
         assert(hasCurrentProgram());
         return programs[currentProgram.load()];
+    }
+
+    void setCurrentProgramDirty(bool isDirty)
+    {
+        assert(hasCurrentProgram());
+        if (hasCurrentProgram())
+            programDirty[currentProgram.load()] = isDirty;
+    }
+
+    bool getIsCurrentProgramDirty() const
+    {
+        assert(hasCurrentProgram());
+        return hasCurrentProgram() && programDirty[currentProgram.load()];
     }
 
     bool hasCurrentProgram() const

--- a/src/engine/Program.h
+++ b/src/engine/Program.h
@@ -25,12 +25,41 @@
 
 #include "ParameterList.h"
 
-class Parameters
+class Program
 {
   public:
-    Parameters() : namePtr(new juce::String("Default")) { setDefaultValues(); }
+    Program() : namePtr(new juce::String("Default")) { setDefaultValues(); }
 
-    ~Parameters() { delete namePtr.load(); }
+    // Copy constructor
+    Program(const Program &other) : namePtr(new juce::String(*other.namePtr.load()))
+    {
+        for (const auto &kv : other.values)
+        {
+            values[kv.first].store(kv.second.load());
+        }
+    }
+
+    // Assignment operator
+    Program &operator=(const Program &other)
+    {
+        if (this != &other)
+        {
+            // Copy values
+            values.clear();
+            for (const auto &kv : other.values)
+            {
+                values[kv.first].store(kv.second.load());
+            }
+
+            // Copy name
+            auto *newStr = new juce::String(*other.namePtr.load());
+            const auto *oldStr = namePtr.exchange(newStr);
+            delete oldStr;
+        }
+        return *this;
+    }
+
+    ~Program() { delete namePtr.load(); }
 
     void setDefaultValues()
     {

--- a/src/engine/SynthEngine.h
+++ b/src/engine/SynthEngine.h
@@ -26,7 +26,7 @@
 #include <core/Constants.h>
 #include "Voice.h"
 #include "Motherboard.h"
-#include "Parameters.h"
+#include "Program.h"
 #include "Smoother.h"
 
 class SynthEngine

--- a/src/parameter/ParameterAdapter.cpp
+++ b/src/parameter/ParameterAdapter.cpp
@@ -1,0 +1,32 @@
+/*
+ * OB-Xf - a continuation of the last open source version of OB-Xd.
+ *
+ * OB-Xd was originally written by Vadim Filatov, and then a version
+ * was released under the GPL3 at https://github.com/reales/OB-Xd.
+ * Subsequently, the product was continued by DiscoDSP and the copyright
+ * holders as an excellent closed source product. For more info,
+ * see "HISTORY.md" in the root of this repository.
+ *
+ * This repository is a successor to the last open source release,
+ * a version marked as 2.11. Copyright 2013-2025 by the authors
+ * as indicated in the original release, and subsequent authors
+ * per the GitHub transaction log.
+ *
+ * OB-Xf is released under the GNU General Public Licence v3 or later
+ * (GPL-3.0-or-later). The license is found in the file "LICENSE"
+ * in the root of this repository or at:
+ * https://www.gnu.org/licenses/gpl-3.0.en.html
+ *
+ * Source code is available at https://github.com/surge-synthesizer/OB-Xf
+ */
+
+#include "ParameterAdapter.h"
+
+ParameterManagerAdapter::ParameterManagerAdapter(IParameterState &paramState,
+                                                 IProgramState &progState,
+                                                 ObxfAudioProcessor &processor, SynthEngine &synth)
+    : parameterState(paramState), programState(progState), paramManager(processor, ParameterList),
+      engine(synth)
+{
+    setupParameterCallbacks();
+}

--- a/src/parameter/ParameterAdapter.h
+++ b/src/parameter/ParameterAdapter.h
@@ -43,18 +43,15 @@ enum RandomAlgos
     PANS,
 };
 
+class ObxfAudioProcessor;
+
 class ParameterManagerAdapter
 {
   public:
     ValueAttachment<bool> midiLearnAttachment{};
 
     ParameterManagerAdapter(IParameterState &paramState, IProgramState &progState,
-                            juce::AudioProcessor &processor, SynthEngine &synth)
-        : parameterState(paramState), programState(progState),
-          paramManager(processor, ParameterList), engine(synth)
-    {
-        setupParameterCallbacks();
-    }
+                            ObxfAudioProcessor &processor, SynthEngine &synth);
 
     void setEngineParameterValue(SynthEngine & /*synth*/, const juce::String &paramId,
                                  float newValue, bool notifyToHost = false)

--- a/src/parameter/ParameterManager.cpp
+++ b/src/parameter/ParameterManager.cpp
@@ -22,10 +22,11 @@
 
 #include "ParameterManager.h"
 #include "SynthParam.h"
+#include "PluginProcessor.h"
 
-ParameterManager::ParameterManager(juce::AudioProcessor &audioProcessor,
+ParameterManager::ParameterManager(ObxfAudioProcessor &audioProcessor,
                                    const std::vector<ParameterInfo> &_parameters)
-    : parameters{_parameters}
+    : parameters{_parameters}, audioProcessor{audioProcessor}
 {
     for (const auto &info : parameters)
     {
@@ -232,5 +233,13 @@ void ParameterManager::flushParameterQueue()
     if (processed > 0)
     {
         DBG("Flushed " + juce::String(processed) + " parameters from FIFO: " + processedParams);
+    }
+}
+
+void ParameterManager::parameterGestureChanged(int, bool)
+{
+    if (!supressGestureToDirty)
+    {
+        audioProcessor.setCurrentProgramDirtyState(true);
     }
 }

--- a/src/parameter/ParameterManager.h
+++ b/src/parameter/ParameterManager.h
@@ -32,12 +32,14 @@
 
 #include <unordered_map>
 
+class ObxfAudioProcessor;
+
 class ParameterManager : public juce::AudioProcessorParameter::Listener
 {
   public:
     using Callback = std::function<void(float value, bool forced)>;
 
-    ParameterManager(juce::AudioProcessor &audioProcessor,
+    ParameterManager(ObxfAudioProcessor &audioProcessor,
                      const std::vector<ParameterInfo> &parameters);
 
     ParameterManager() = delete;
@@ -50,7 +52,7 @@ class ParameterManager : public juce::AudioProcessorParameter::Listener
 
     void parameterValueChanged(int parameterIndex, float newValue) override;
 
-    void parameterGestureChanged(int /*parameterIndex*/, bool /*gestureIsStarting*/) override {}
+    void parameterGestureChanged(int /*parameterIndex */, bool /* gesture */) override;
 
     void flushParameterQueue();
 
@@ -70,9 +72,12 @@ class ParameterManager : public juce::AudioProcessorParameter::Listener
     void addParameter(const juce::String &paramID, juce::RangedAudioParameter *param);
     void queueParameterChange(const juce::String &paramID, float newValue);
 
+    void setSupressGestureToDirty(bool state) { supressGestureToDirty = state; }
+
   private:
     FIFO<128> fifo;
     std::vector<ParameterInfo> parameters;
+    ObxfAudioProcessor &audioProcessor;
 
     std::unordered_map<juce::String, std::unordered_map<juce::String, Callback>> callbacks;
     std::unordered_map<juce::String, juce::RangedAudioParameter *> paramMap;
@@ -83,6 +88,8 @@ class ParameterManager : public juce::AudioProcessorParameter::Listener
      * editor will modify the callback structure to remove its hooks
      */
     std::mutex callbackMutex;
+
+    bool supressGestureToDirty{false};
 
     JUCE_DECLARE_NON_COPYABLE(ParameterManager)
 

--- a/src/state/StateManager.cpp
+++ b/src/state/StateManager.cpp
@@ -72,7 +72,7 @@ void StateManager::getCurrentProgramStateInformation(juce::MemoryBlock &destData
 
     if (const auto &bank = audioProcessor->getCurrentBank(); bank.hasCurrentProgram())
     {
-        const Parameters &prog = bank.getCurrentProgram();
+        const Program &prog = bank.getCurrentProgram();
         for (const auto *param : ObxfAudioProcessor::ObxfParams(*audioProcessor))
         {
             const auto &paramId = param->paramID;
@@ -141,6 +141,7 @@ void StateManager::setStateInformation(const void *data, int sizeInBytes,
 
                 program.setName(e->getStringAttribute(S("programName"), S("Default")));
 
+                bank.originalPrograms[i] = program;
                 ++i;
             }
         }
@@ -168,7 +169,7 @@ void StateManager::setCurrentProgramStateInformation(const void *data, const int
     {
         if (auto &bank = audioProcessor->getCurrentBank(); bank.hasCurrentProgram())
         {
-            Parameters &prog = bank.getCurrentProgram();
+            Program &prog = bank.getCurrentProgram();
             prog.setDefaultValues();
             const bool newFormat = e->hasAttribute("voiceCount");
 


### PR DESCRIPTION
Addresses #428

This commit basically adds a program double buffer and detects when the program is changed so we can 'restore' to factory on a per patch basis. Its an incomplete implementation of #428 but I'm merging it so we can test this step zero workflow.

Still to do include

- save all to original
- bank export undirties
- daw save undirties
- testing