### PR TITLE
Stream DirtyState and BackPatch to state information

### DIFF
--- a/src/PluginProcessor.cpp
+++ b/src/PluginProcessor.cpp
@@ -269,6 +269,7 @@ const juce::String ObxfAudioProcessor::getProgramName(const int index)
 void ObxfAudioProcessor::changeProgramName(const int index, const juce::String &newName)
 {
     currentBank.programs[index].setName(newName);
+    currentBank.setProgramDirty(index, true);
 }
 
 bool ObxfAudioProcessor::hasEditor() const { return true; }

--- a/src/engine/Bank.h
+++ b/src/engine/Bank.h
@@ -48,6 +48,10 @@ class Bank
         return programs[currentProgram.load()];
     }
 
+    void setProgramDirty(size_t idx, bool isDirty) { programDirty[idx] = isDirty; }
+
+    bool getIsProgramDirty(size_t idx) const { return programDirty[idx]; }
+
     void setCurrentProgramDirty(bool isDirty)
     {
         assert(hasCurrentProgram());


### PR DESCRIPTION
When you save state, rather than assuming front->back in the patch store, we instead stream that dirty state and the back patch along with it. This means that a stream doesn't change your workflow and you pick up where you left off.