### PR TITLE
Replace RMB on LFO target buttons with Ctrl/Cmd+click

### DIFF
--- a/src/PluginEditor.cpp
+++ b/src/PluginEditor.cpp
@@ -1458,28 +1458,41 @@ void ObxfAudioProcessorEditor::createComponentsFromXml(const juce::XmlElement *d
                 selectButtons[whichIdx]->setClickingTogglesState(false);
 
                 auto safeThis = SafePointer(this);
-                selectButtons[whichIdx]->onClick = [safeThis, whichIdx]() {
+
+                selectButtons[whichIdx]->onStateChange = [safeThis, whichIdx]() {
                     if (!safeThis)
                         return;
-                    uint8_t curGroup =
-                        safeThis->processor.getCurrentProgram() / NUM_PATCHES_PER_GROUP;
-                    uint8_t curPatchInGroup =
-                        safeThis->processor.getCurrentProgram() % NUM_PATCHES_PER_GROUP;
 
-                    if (safeThis->groupSelectButton->getToggleState())
-                        curGroup = whichIdx;
-                    else
-                        curPatchInGroup = whichIdx;
+                    if (safeThis->selectButtons[whichIdx]->isDown())
+                    {
+                        auto cmd = juce::ModifierKeys::getCurrentModifiers().isCommandDown();
 
-                    safeThis->processor.setCurrentProgram((curGroup * NUM_PATCHES_PER_GROUP) +
-                                                          curPatchInGroup);
-                    safeThis->needNotifyToHost = true;
-                    safeThis->countTimer = 0;
-                };
+                        uint8_t curGroup =
+                            safeThis->processor.getCurrentProgram() / NUM_PATCHES_PER_GROUP;
+                        uint8_t curPatchInGroup =
+                            safeThis->processor.getCurrentProgram() % NUM_PATCHES_PER_GROUP;
 
-                selectButtons[whichIdx]->onStateChange = [safeThis]() {
-                    if (!safeThis)
-                        return;
+                        if (safeThis->groupSelectButton->getToggleState())
+                        {
+                            if (cmd)
+                                curPatchInGroup = whichIdx;
+                            else
+                                curGroup = whichIdx;
+                        }
+                        else
+                        {
+                            if (cmd)
+                                curGroup = whichIdx;
+                            else
+                                curPatchInGroup = whichIdx;
+                        }
+
+                        safeThis->processor.setCurrentProgram((curGroup * NUM_PATCHES_PER_GROUP) +
+                                                              curPatchInGroup);
+                        safeThis->needNotifyToHost = true;
+                        safeThis->countTimer = 0;
+                    }
+
                     safeThis->updateSelectButtonStates();
                 };
             }

--- a/src/gui/MultiStateButton.h
+++ b/src/gui/MultiStateButton.h
@@ -110,21 +110,15 @@ class MultiStateButton final : public juce::Slider, public HasScaleFactor
             }
         }
 
-        if (mouseButtonPressed == None)
+        if (event.mods.isLeftButtonDown())
         {
-            const auto isLeft = event.mods.isLeftButtonDown();
-            const auto isRight = event.mods.isRightButtonDown();
+            counter = (counter + numStates + (event.mods.isCommandDown() ? -1 : 1)) % numStates;
 
-            if (isLeft || isRight)
-            {
-                counter = (counter + numStates + (isRight ? -1 : 1)) % numStates;
-
-                setValue((double)counter / (numStates - 1));
-                repaint();
-
-                mouseButtonPressed = isRight ? Right : Left;
-            }
+            setValue((double)counter / (numStates - 1));
         }
+
+        mouseButtonPressed = true;
+        repaint();
     }
 
     void valueChanged() override
@@ -134,20 +128,16 @@ class MultiStateButton final : public juce::Slider, public HasScaleFactor
         repaint();
     }
 
-    void mouseUp(const juce::MouseEvent &event) override
+    void mouseUp(const juce::MouseEvent & /* event */) override
     {
-        if ((mouseButtonPressed == Left && event.mods.isLeftButtonDown()) ||
-            (mouseButtonPressed == Right && event.mods.isRightButtonDown()))
-        {
-            mouseButtonPressed = None;
+        mouseButtonPressed = false;
 
-            repaint();
-        }
+        repaint();
     }
 
     void paint(juce::Graphics &g) override
     {
-        const int ofs = (counter * 2) + (mouseButtonPressed > None);
+        const int ofs = (counter * 2) + mouseButtonPressed;
 
         if (isSVG)
         {
@@ -174,13 +164,7 @@ class MultiStateButton final : public juce::Slider, public HasScaleFactor
   private:
     juce::Image kni;
 
-    enum MouseButtonPressed
-    {
-        None,
-        Left,
-        Right
-    } mouseButtonPressed{None};
-
+    bool mouseButtonPressed{false};
     int counter{0};
     int numStates{3}, numFrames{6};
     int width, height, h2;

--- a/src/gui/ToggleButton.h
+++ b/src/gui/ToggleButton.h
@@ -125,12 +125,10 @@ class ToggleButton final : public juce::ImageButton, public HasScaleFactor
                     obxf->setLastUsedParameter(parameter->paramID);
                 }
             }
-
-            ImageButton::mouseDown(event);
         }
-    }
 
-    // void mouseUp(const juce::MouseEvent &event) override { ImageButton::mouseUp(event); }
+        ImageButton::mouseDown(event);
+    }
 
     bool keyPressed(const juce::KeyPress &e) override
     {


### PR DESCRIPTION
This will allow us to use context menu on buttons down the line if we wanted it (for consistency with knobs, we have the same in Surge XT).

Also, make it so that Ctrl/Cmd+clicking the 16 patch switching buttons will behave inverse to the state of the Group button.