### PR TITLE
Add copy-paste options to patch 1-16 buttons

### DIFF
--- a/src/PluginEditor.cpp
+++ b/src/PluginEditor.cpp
@@ -49,7 +49,7 @@ struct IdleTimer : juce::Timer
 
 //==============================================================================
 ObxfAudioProcessorEditor::ObxfAudioProcessorEditor(ObxfAudioProcessor &p)
-    : AudioProcessorEditor(&p), utils(p.getUtils()), processor(p),
+    : AudioProcessorEditor(&p), processor(p), utils(p.getUtils()),
       paramAdapter(p.getParamAdapter()), imageCache(utils), midiStart(5000), sizeStart(4000),
       presetStart(3000), bankStart(2000), themeStart(1000), themes(utils.getThemeLocations()),
       banks(utils.getBankLocations())
@@ -662,8 +662,9 @@ void ObxfAudioProcessorEditor::createComponentsFromXml(const juce::XmlElement *d
                 return juce::jmap(static_cast<double>(semitoneValue), -24.0, 24.0, 0.0, 1.0);
             };
             osc1PitchKnob->altDragCallback = [](const double value) {
-                const auto octValue = static_cast<int>(juce::jmap(value, -2.0, 2.0));
-                return juce::jmap(static_cast<double>(octValue), -2.0, 2.0, 0.0, 1.0);
+                const int values[13]{-24, -19, -17, -12, -7, -5, 0, 5, 7, 12, 17, 19, 24};
+                const auto snapValue = static_cast<int>(juce::jmap(value, 0.0, 12.0));
+                return juce::jmap(static_cast<double>(values[snapValue]), -24.0, 24.0, 0.0, 1.0);
             };
             componentMap[name] = osc1PitchKnob.get();
         }
@@ -682,8 +683,9 @@ void ObxfAudioProcessorEditor::createComponentsFromXml(const juce::XmlElement *d
                 return juce::jmap(static_cast<double>(semitoneValue), -24.0, 24.0, 0.0, 1.0);
             };
             osc2PitchKnob->altDragCallback = [](const double value) {
-                const auto octValue = static_cast<int>(juce::jmap(value, -2.0, 2.0));
-                return juce::jmap(static_cast<double>(octValue), -2.0, 2.0, 0.0, 1.0);
+                const int values[13]{-24, -19, -17, -12, -7, -5, 0, 5, 7, 12, 17, 19, 24};
+                const auto snapValue = static_cast<int>(juce::jmap(value, 0.0, 12.0));
+                return juce::jmap(static_cast<double>(values[snapValue]), -24.0, 24.0, 0.0, 1.0);
             };
             componentMap[name] = osc2PitchKnob.get();
         }
@@ -741,8 +743,9 @@ void ObxfAudioProcessorEditor::createComponentsFromXml(const juce::XmlElement *d
                 return juce::jmap(static_cast<double>(semitoneValue), 0.0, 36.0, 0.0, 1.0);
             };
             envToPitchAmountKnob->altDragCallback = [](const double value) {
-                const auto octValue = static_cast<int>(juce::jmap(value, 0.0, 3.0));
-                return juce::jmap(static_cast<double>(octValue), 0.0, 3.0, 0.0, 1.0);
+                const int values[10]{0, 5, 7, 12, 17, 19, 24, 29, 31, 36};
+                const auto snapValue = static_cast<int>(juce::jmap(value, 0.0, 9.0));
+                return juce::jmap(static_cast<double>(values[snapValue]), 0.0, 36.0, 0.0, 1.0);
             };
             componentMap[name] = envToPitchAmountKnob.get();
         }
@@ -1170,10 +1173,6 @@ void ObxfAudioProcessorEditor::createComponentsFromXml(const juce::XmlElement *d
         {
             transposeKnob = addKnob(x, y, w, h, d, fh, ID::Transpose, 0.5f, Name::Transpose,
                                     useAssetOrDefault(pic, "knob"));
-            transposeKnob->cmdDragCallback = [](const double value) {
-                const auto semitoneValue = static_cast<int>(juce::jmap(value, -24.0, 24.0));
-                return juce::jmap(static_cast<double>(semitoneValue), -24.0, 24.0, 0.0, 1.0);
-            };
             transposeKnob->altDragCallback = [](const double value) {
                 const auto octValue = static_cast<int>(juce::jmap(value, -2.0, 2.0));
                 return juce::jmap(static_cast<double>(octValue), -2.0, 2.0, 0.0, 1.0);
@@ -1473,32 +1472,36 @@ void ObxfAudioProcessorEditor::createComponentsFromXml(const juce::XmlElement *d
 
                     if (safeThis->selectButtons[whichIdx]->isDown())
                     {
+                        auto right = juce::ModifierKeys::getCurrentModifiers().isRightButtonDown();
                         auto cmd = juce::ModifierKeys::getCurrentModifiers().isCommandDown();
 
-                        uint8_t curGroup =
-                            safeThis->processor.getCurrentProgram() / NUM_PATCHES_PER_GROUP;
-                        uint8_t curPatchInGroup =
-                            safeThis->processor.getCurrentProgram() % NUM_PATCHES_PER_GROUP;
-
-                        if (safeThis->groupSelectButton->getToggleState())
+                        if (!right)
                         {
-                            if (cmd)
-                                curPatchInGroup = whichIdx;
-                            else
-                                curGroup = whichIdx;
-                        }
-                        else
-                        {
-                            if (cmd)
-                                curGroup = whichIdx;
-                            else
-                                curPatchInGroup = whichIdx;
-                        }
+                            uint8_t curGroup =
+                                safeThis->processor.getCurrentProgram() / NUM_PATCHES_PER_GROUP;
+                            uint8_t curPatchInGroup =
+                                safeThis->processor.getCurrentProgram() % NUM_PATCHES_PER_GROUP;
 
-                        safeThis->processor.setCurrentProgram((curGroup * NUM_PATCHES_PER_GROUP) +
-                                                              curPatchInGroup);
-                        safeThis->needNotifyToHost = true;
-                        safeThis->countTimer = 0;
+                            if (safeThis->groupSelectButton->getToggleState())
+                            {
+                                if (cmd)
+                                    curPatchInGroup = whichIdx;
+                                else
+                                    curGroup = whichIdx;
+                            }
+                            else
+                            {
+                                if (cmd)
+                                    curGroup = whichIdx;
+                                else
+                                    curPatchInGroup = whichIdx;
+                            }
+
+                            safeThis->processor.setCurrentProgram(
+                                (curGroup * NUM_PATCHES_PER_GROUP) + curPatchInGroup);
+                            safeThis->needNotifyToHost = true;
+                            safeThis->countTimer = 0;
+                        }
                     }
 
                     safeThis->updateSelectButtonStates();
@@ -2761,13 +2764,13 @@ void ObxfAudioProcessorEditor::MenuActionCallback(int action)
     // Copy to clipboard
     if (action == MenuAction::CopyPatch)
     {
-        utils.copyPatch(-1);
+        utils.copyPatch();
     }
 
     // Paste from clipboard
     if (action == MenuAction::PastePatch)
     {
-        utils.pastePatch(&processor, -1);
+        utils.pastePatch();
     }
 
     if (action == MenuAction::RevealUserDirectory)

--- a/src/PluginProcessor.cpp
+++ b/src/PluginProcessor.cpp
@@ -327,6 +327,11 @@ void ObxfAudioProcessor::initializeUtilsCallbacks()
         return loadFromMemoryBlock(mb, index);
     };
 
+    utils->pastePatchCallback = [this](juce::MemoryBlock &mb, const int index) {
+        loadFromMemoryBlock(mb, index);
+        setProgramDirtyState(index, true);
+    };
+
     utils->getStateInformationCallback = [this](juce::MemoryBlock &mb) { getStateInformation(mb); };
 
     utils->getNumProgramsCallback = [this]() { return getNumPrograms(); };

--- a/src/PluginProcessor.h
+++ b/src/PluginProcessor.h
@@ -153,7 +153,7 @@ class ObxfAudioProcessor final : public juce::AudioProcessor,
     void setEngineParameterValue(const juce::String &paramId, float newValue,
                                  bool notifyToHost = false);
 
-    bool loadFromMemoryBlock(juce::MemoryBlock &mb) const;
+    bool loadFromMemoryBlock(juce::MemoryBlock &mb, const int index = -1) const;
 
     Utils &getUtils() const { return *utils; }
 
@@ -161,6 +161,8 @@ class ObxfAudioProcessor final : public juce::AudioProcessor,
 
     void saveAllFrontProgramsToBack();
     void saveSpecificFrontProgramToBack(int index);
+
+    int getCurrentPatchGroup() { return currentBank.currentProgram / NUM_PATCHES_PER_GROUP; }
 
     void randomizeToAlgo(RandomAlgos algo);
     void panSetter(PanAlgos alg);
@@ -232,10 +234,13 @@ class ObxfAudioProcessor final : public juce::AudioProcessor,
     void updateUIState();
 
     void setCurrentProgramDirtyState(bool isDirty);
+    void setProgramDirtyState(bool isDirty, const int index = -1);
     void restoreCurrentProgramToOriginalState();
     void saveCurrentProgramAsOriginalState();
 
     MidiHandler &getMidiHandler() { return midiHandler; }
+
+    std::unique_ptr<Utils> utils;
 
   private:
     std::atomic<bool> isHostAutomatedChange{};
@@ -243,7 +248,6 @@ class ObxfAudioProcessor final : public juce::AudioProcessor,
     Bank currentBank;
     MidiMap bindings;
 
-    std::unique_ptr<Utils> utils;
     std::unique_ptr<ParameterManagerAdapter> paramAdapter;
     MidiHandler midiHandler;
     juce::UndoManager undoManager;

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -384,12 +384,9 @@ juce::MemoryBlock Utils::serializePatch(juce::MemoryBlock &memoryBlock, const in
 {
     juce::MemoryBlock m;
 
-    if (getCurrentProgramStateInformation && getProgramStateInformation)
+    if (getProgramStateInformation)
     {
-        if (index < 0)
-            getCurrentProgramStateInformation(m);
-        else
-            getProgramStateInformation(index, m);
+        getProgramStateInformation(index, m);
 
         memoryBlock.reset();
         const auto totalLen = sizeof(fxProgramSet) + m.getSize() - 8;
@@ -501,14 +498,13 @@ void Utils::copyPatch(const int index)
     juce::SystemClipboard::copyTextToClipboard(serializedData.toBase64Encoding());
 }
 
-void Utils::pastePatch(ObxfAudioProcessor *processor, const int index)
+void Utils::pastePatch(const int index)
 {
-    if (processor)
+    if (pastePatchCallback)
     {
         juce::MemoryBlock memoryBlock;
         memoryBlock.fromBase64Encoding(juce::SystemClipboard::getTextFromClipboard());
-        processor->loadFromMemoryBlock(memoryBlock, index);
-        processor->setProgramDirtyState(index, true);
+        pastePatchCallback(memoryBlock, index);
     }
 }
 

--- a/src/Utils.h
+++ b/src/Utils.h
@@ -155,7 +155,6 @@ class Utils final
     bool getUseSoftwareRenderer() const;
 
     // banks
-    bool deleteBank();
     void saveBank() const;
     bool saveBank(const juce::File &fxbFile);
 
@@ -171,11 +170,15 @@ class Utils final
 
     void savePatch();
 
-    void serializePatch(juce::MemoryBlock &memoryBlock) const;
+    // negative index means current patch!
+    void copyPatch(const int index = -1);
+    void pastePatch(ObxfAudioProcessor *processor, const int index = -1);
+
+    bool isPatchInClipboard();
+
+    juce::MemoryBlock serializePatch(juce::MemoryBlock &memoryBlock, const int index = -1) const;
 
     void changePatchName(const juce::String &name) const;
-
-    void newPatch(const juce::String &name) const;
 
     void initializePatch() const;
 
@@ -193,12 +196,14 @@ class Utils final
     }
 
     // callbacks
-    std::function<bool(juce::MemoryBlock &)> loadMemoryBlockCallback;
+    std::function<bool(juce::MemoryBlock &, const int)> loadMemoryBlockCallback;
     std::function<void(juce::MemoryBlock &)> getStateInformationCallback;
     std::function<int()> getNumProgramsCallback;
     std::function<void(juce::MemoryBlock &)> getCurrentProgramStateInformation;
+    std::function<void(const uint8_t, juce::MemoryBlock &)> getProgramStateInformation;
     std::function<int()> getNumPrograms;
-    std::function<void(char *, int)> copyProgramNameToBuffer;
+    std::function<void(char *, int)> copyCurrentProgramNameToBuffer;
+    std::function<void(const uint8_t, char *, int)> copyProgramNameToBuffer;
     std::function<void(const juce::String &)> setPatchName;
     std::function<void()> resetPatchToDefault;
     std::function<void()> sendChangeMessage;

--- a/src/Utils.h
+++ b/src/Utils.h
@@ -170,9 +170,11 @@ class Utils final
 
     void savePatch();
 
+    std::function<void(juce::MemoryBlock &, const int)> pastePatchCallback;
+
     // negative index means current patch!
     void copyPatch(const int index = -1);
-    void pastePatch(ObxfAudioProcessor *processor, const int index = -1);
+    void pastePatch(const int index = -1);
 
     bool isPatchInClipboard();
 
@@ -190,6 +192,7 @@ class Utils final
 
     // should refactor all callbacks to be like this? or not? :-)
     using HostUpdateCallback = std::function<void()>;
+
     void setHostUpdateCallback(HostUpdateCallback callback)
     {
         hostUpdateCallback = std::move(callback);

--- a/src/engine/Bank.h
+++ b/src/engine/Bank.h
@@ -65,6 +65,8 @@ class Bank
         return hasCurrentProgram() && programDirty[currentProgram.load()];
     }
 
+    bool hasProgram(const int idx) const { return idx >= 0 && idx < MAX_PROGRAMS; }
+
     bool hasCurrentProgram() const
     {
         int idx = currentProgram.load();

--- a/src/gui/ToggleButton.h
+++ b/src/gui/ToggleButton.h
@@ -153,25 +153,47 @@ class ToggleButton final : public juce::ImageButton, public HasScaleFactor
         {
             auto *obxf = dynamic_cast<ObxfAudioProcessor *>(owner);
 
-            menu.addSectionHeader("Save Options");
-            menu.addSeparator();
-            menu.addItem(toOSCase("Save All Patches in Bank"), [obxf]() {
-                if (obxf)
-                {
-                    obxf->saveAllFrontProgramsToBack();
-                }
-            });
-            menu.addItem(toOSCase("Save All Patches in Current Group"), [obxf]() {
-                if (obxf)
-                {
+            if (obxf)
+            {
+                menu.addSectionHeader("Save Options");
+
+                menu.addSeparator();
+
+                menu.addItem(toOSCase("Save All Patches in Bank"),
+                             [obxf]() { obxf->saveAllFrontProgramsToBack(); });
+
+                menu.addItem(toOSCase("Save All Patches in Current Group"), [obxf]() {
                     const uint8_t curGrp = obxf->getCurrentProgram() / NUM_PATCHES_PER_GROUP;
 
                     for (int i = 0; i < NUM_PATCHES_PER_GROUP; i++)
                     {
                         obxf->saveSpecificFrontProgramToBack((curGrp * NUM_PATCHES_PER_GROUP) + i);
                     }
-                }
-            });
+                });
+            }
+        }
+
+        if (auto name = getTitle(); std::isdigit(name.getLastCharacter()))
+        {
+            auto *obxf = dynamic_cast<ObxfAudioProcessor *>(owner);
+
+            if (obxf)
+            {
+                auto which = name.retainCharacters("0123456789").getIntValue();
+                const int idx = (obxf->getCurrentPatchGroup() * NUM_PATCHES_PER_GROUP) + which;
+
+                menu.addSectionHeader("Patch Options");
+
+                menu.addSeparator();
+
+                menu.addItem(toOSCase(std::format("Copy Patch {}", idx)),
+                             [obxf, idx]() { obxf->utils->copyPatch(idx - 1); });
+
+                bool ticked = obxf->utils->isPatchInClipboard();
+
+                menu.addItem(toOSCase(std::format("Paste to Patch {}", idx)), ticked, false,
+                             [obxf, idx]() { obxf->utils->pastePatch(obxf, idx - 1); });
+            }
         }
 
         menu.showMenuAsync(juce::PopupMenu::Options().withParentComponent(getTopLevelComponent()));

--- a/src/gui/ToggleButton.h
+++ b/src/gui/ToggleButton.h
@@ -125,9 +125,9 @@ class ToggleButton final : public juce::ImageButton, public HasScaleFactor
                     obxf->setLastUsedParameter(parameter->paramID);
                 }
             }
-        }
 
-        ImageButton::mouseDown(event);
+            ImageButton::mouseDown(event);
+        }
     }
 
     bool keyPressed(const juce::KeyPress &e) override
@@ -186,13 +186,13 @@ class ToggleButton final : public juce::ImageButton, public HasScaleFactor
 
                 menu.addSeparator();
 
-                menu.addItem(toOSCase(std::format("Copy Patch {}", idx)),
+                menu.addItem(toOSCase(fmt::format("Copy Patch {}", idx)),
                              [obxf, idx]() { obxf->utils->copyPatch(idx - 1); });
 
-                bool ticked = obxf->utils->isPatchInClipboard();
+                bool enabled = obxf->utils->isPatchInClipboard();
 
-                menu.addItem(toOSCase(std::format("Paste to Patch {}", idx)), ticked, false,
-                             [obxf, idx]() { obxf->utils->pastePatch(obxf, idx - 1); });
+                menu.addItem(toOSCase(fmt::format("Paste to Patch {}", idx)), enabled, false,
+                             [obxf, idx]() { obxf->utils->pastePatch(idx - 1); });
             }
         }
 

--- a/src/parameter/ParameterList.h
+++ b/src/parameter/ParameterList.h
@@ -78,7 +78,7 @@ inline pmd tristateLFOTo()
 static const std::vector<ParameterInfo> ParameterList{
     // <-- MASTER -->
     {ID::Volume, pmd().asFloat().withName(Name::Volume).withRange(0.f, 1.f).asPercent().withDefault(0.5f).withDecimalPlaces(1).withID(1008)},
-    {ID::Transpose, pmd().asFloat().withName(Name::Transpose).asSemitoneRange(-24.f, 24.f).withDecimalPlaces(2).withID(2112)},
+    {ID::Transpose, pmd().asFloat().withName(Name::Transpose).asSemitoneRange(-24.f, 24.f).withDecimalPlaces(0).withID(2112)},
     {ID::Tune, pmd().asFloat().withName(Name::Tune).withRange(-100.f, 100.f).withLinearScaleFormatting("cents").withDecimalPlaces(1).withID(5150)},
 
     // <-- GLOBAL -->

--- a/src/state/StateManager.cpp
+++ b/src/state/StateManager.cpp
@@ -119,6 +119,27 @@ void StateManager::getCurrentProgramStateInformation(juce::MemoryBlock &destData
     juce::AudioProcessor::copyXmlToBinary(xmlState, destData);
 }
 
+void StateManager::getProgramStateInformation(const int index, juce::MemoryBlock &destData) const
+{
+    auto xmlState = juce::XmlElement("OB-Xf");
+
+    if (const auto &bank = audioProcessor->getCurrentBank(); bank.hasProgram(index))
+    {
+        const Program &prog = bank.programs[index];
+        for (const auto *param : ObxfAudioProcessor::ObxfParams(*audioProcessor))
+        {
+            const auto &paramId = param->paramID;
+            auto it = prog.values.find(paramId);
+            const float value = (it != prog.values.end()) ? it->second.load() : 0.0f;
+            xmlState.setAttribute(paramId, value);
+        }
+        xmlState.setAttribute(S("voiceCount"), MAX_VOICES);
+        xmlState.setAttribute(S("programName"), prog.getName());
+    }
+
+    juce::AudioProcessor::copyXmlToBinary(xmlState, destData);
+}
+
 void StateManager::setStateInformation(const void *data, int sizeInBytes,
                                        bool restoreCurrentProgram)
 {
@@ -277,10 +298,11 @@ void StateManager::setCurrentProgramStateInformation(const void *data, const int
     }
 }
 
-bool StateManager::loadFromMemoryBlock(juce::MemoryBlock &mb)
+bool StateManager::loadFromMemoryBlock(juce::MemoryBlock &mb, const int index)
 {
     const void *const data = mb.getData();
     const size_t dataSize = mb.getSize();
+    const int idx = (index < 0) ? audioProcessor->getCurrentProgram() : index;
 
     if (dataSize < 28)
         return false;
@@ -290,9 +312,8 @@ bool StateManager::loadFromMemoryBlock(juce::MemoryBlock &mb)
     if ((!compareMagic(set->chunkMagic, "CcnK")) || fxbSwap(set->version) > fxbVersionNum)
         return false;
 
-    if (compareMagic(set->fxMagic, "FxBk"))
+    if (compareMagic(set->fxMagic, "FxBk")) // bank of programs
     {
-        // bank of programs
         if (fxbSwap(set->numPrograms) >= 0)
         {
             const int oldProg = audioProcessor->getCurrentProgram();
@@ -329,29 +350,29 @@ bool StateManager::loadFromMemoryBlock(juce::MemoryBlock &mb)
             if (!restoreProgramSettings(prog))
                 return false;
         }
+
         audioProcessor->saveAllFrontProgramsToBack();
     }
-    else if (compareMagic(set->fxMagic, "FxCk"))
+    else if (compareMagic(set->fxMagic, "FxCk")) // single program
     {
-        // single program
         const auto *const prog = static_cast<const fxProgram *>(data);
 
         if (!compareMagic(prog->chunkMagic, "CcnK"))
             return false;
 
-        audioProcessor->changeProgramName(audioProcessor->getCurrentProgram(), prog->prgName);
+        audioProcessor->changeProgramName(idx, prog->prgName);
 
         for (int i = 0; i < fxbSwap(prog->numParams); ++i)
         {
             const auto &paramId = ParameterList[i].ID;
             audioProcessor->setEngineParameterValue(paramId, fxbSwapFloat(prog->params[i]));
         }
-        audioProcessor->setCurrentProgram(audioProcessor->getCurrentProgram(), true);
-        audioProcessor->saveSpecificFrontProgramToBack(audioProcessor->getCurrentProgram());
+
+        audioProcessor->setCurrentProgram(idx, true);
+        audioProcessor->saveSpecificFrontProgramToBack(idx);
     }
-    else if (compareMagic(set->fxMagic, "FBCh"))
+    else if (compareMagic(set->fxMagic, "FBCh")) // bank memory chunk
     {
-        // non-patch chunk
         const auto *const cset = static_cast<const fxChunkSet *>(data);
 
         if (static_cast<size_t>(fxbSwap(cset->chunkSize)) + sizeof(fxChunkSet) - 8 >
@@ -363,9 +384,8 @@ bool StateManager::loadFromMemoryBlock(juce::MemoryBlock &mb)
         const int currentProg = audioProcessor->getCurrentProgram();
         audioProcessor->setCurrentProgram(currentProg, true);
     }
-    else if (compareMagic(set->fxMagic, "FPCh"))
+    else if (compareMagic(set->fxMagic, "FPCh")) // patch memory chunk
     {
-        // patch chunk
         const auto *const cset = static_cast<const fxProgramSet *>(data);
 
         if (static_cast<size_t>(fxbSwap(cset->chunkSize)) + sizeof(fxProgramSet) - 8 >
@@ -374,8 +394,8 @@ bool StateManager::loadFromMemoryBlock(juce::MemoryBlock &mb)
 
         setCurrentProgramStateInformation(cset->chunk, fxbSwap(cset->chunkSize));
 
-        audioProcessor->changeProgramName(audioProcessor->getCurrentProgram(), cset->name);
-        audioProcessor->saveSpecificFrontProgramToBack(audioProcessor->getCurrentProgram());
+        audioProcessor->changeProgramName(idx, cset->name);
+        audioProcessor->saveSpecificFrontProgramToBack(idx);
     }
     else
     {

--- a/src/state/StateManager.h
+++ b/src/state/StateManager.h
@@ -45,17 +45,14 @@ class StateManager final : public juce::ChangeBroadcaster
 
     bool loadFromMemoryBlock(juce::MemoryBlock &mb, const int index = -1);
 
-    bool restoreProgramSettings(const fxProgram *prog) const;
-
     void getStateInformation(juce::MemoryBlock &destData) const;
-
-    void getCurrentProgramStateInformation(juce::MemoryBlock &destData) const;
-
-    void getProgramStateInformation(const int index, juce::MemoryBlock &destData) const;
-
     void setStateInformation(const void *data, int sizeInBytes, bool restoreCurrentProgram);
 
-    void setCurrentProgramStateInformation(const void *data, int sizeInBytes);
+    void getCurrentProgramStateInformation(juce::MemoryBlock &destData) const;
+    void getProgramStateInformation(const int index, juce::MemoryBlock &destData) const;
+    void setProgramStateInformation(const void *data, int sizeInBytes, const int index = -1);
+
+    bool restoreProgramSettings(const fxProgram *prog) const;
 
     /*
      * The DAW Extra State mechanism works as follows

--- a/src/state/StateManager.h
+++ b/src/state/StateManager.h
@@ -43,15 +43,15 @@ class StateManager final : public juce::ChangeBroadcaster
 
     StateManager &operator=(const StateManager &) = delete;
 
-    bool isMemoryBlockAPatch(const juce::MemoryBlock &mb);
-
-    bool loadFromMemoryBlock(juce::MemoryBlock &mb);
+    bool loadFromMemoryBlock(juce::MemoryBlock &mb, const int index = -1);
 
     bool restoreProgramSettings(const fxProgram *prog) const;
 
     void getStateInformation(juce::MemoryBlock &destData) const;
 
     void getCurrentProgramStateInformation(juce::MemoryBlock &destData) const;
+
+    void getProgramStateInformation(const int index, juce::MemoryBlock &destData) const;
 
     void setStateInformation(const void *data, int sizeInBytes, bool restoreCurrentProgram);
 


### PR DESCRIPTION
Closes #443

Also:

- Added Ctrl and Alt drag to Env To Pitch knob
- Transpose knob now only shows integer values (no decimals), because it's always quantized anyways
- Alt+drag on Osc 1/2 Pitch and Env To Pitch knobs was modified to snap to fourths and fifths, in addition to already snapping to octaves