### PR TITLE
Fix a problem where async program change mis-lit dirty

### DIFF
--- a/src/PluginProcessor.h
+++ b/src/PluginProcessor.h
@@ -237,6 +237,7 @@ class ObxfAudioProcessor final : public juce::AudioProcessor,
     void setProgramDirtyState(bool isDirty, const int index = -1);
     void restoreCurrentProgramToOriginalState();
     void saveCurrentProgramAsOriginalState();
+    void sendChangeMessageWithDirtySuppressed();
 
     MidiHandler &getMidiHandler() { return midiHandler; }
 


### PR DESCRIPTION
Basically by (1) doing it synchronously if we are on the main thread and (2) ordering suppress messages if we arent

Closes #446