### PR TITLE
If loading an FXP, prefer the in-xml name

### DIFF
--- a/src/state/StateManager.cpp
+++ b/src/state/StateManager.cpp
@@ -384,7 +384,18 @@ bool StateManager::loadFromMemoryBlock(juce::MemoryBlock &mb, const int index)
 
         setProgramStateInformation(cset->chunk, fxbSwap(cset->chunkSize), idx);
 
-        audioProcessor->changeProgramName(idx, cset->name);
+        auto &bn = audioProcessor->getCurrentBank().programs[idx];
+        std::string progName(bn.getName().toStdString());
+        std::string fxpName(cset->name); // caps at 28 chars
+
+        if (fxpName.empty() || (!progName.empty() && progName != "Default"))
+        {
+            audioProcessor->changeProgramName(idx, progName.c_str());
+        }
+        else
+        {
+            audioProcessor->changeProgramName(idx, cset->name);
+        }
         audioProcessor->saveSpecificFrontProgramToBack(idx);
     }
     else


### PR DESCRIPTION
If loading an FXP which has a name both in the XML and a name in the FXP, prefer the XML name all things being equal, allowing fxp with name > 28 chars to restore the name on reload after the fxp round trip.

Closes #449