### PR TITLE
Fix a problem with on-startup factory bank load

### DIFF
--- a/src/PluginProcessor.cpp
+++ b/src/PluginProcessor.cpp
@@ -59,6 +59,8 @@ ObxfAudioProcessor::ObxfAudioProcessor()
     options.millisecondsBeforeSaving = 2500;
 
     midiHandler.initMidi();
+
+    utils->loadFactoryBank();
 }
 #endif
 

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -49,10 +49,6 @@ Utils::Utils() : configLock("__" JucePlugin_Name "ConfigLock__")
     // std::cout << "[Utils::Utils] Current theme: " << currentTheme.toStdString() << std::endl;
     scanAndUpdateBanks();
     scanAndUpdateThemes();
-    if (bankLocations.size() > 0)
-    {
-        loadFromFXBFile(bankLocations[0].file);
-    }
 
     if (themeLocations.size() > 0 && !currentTheme.file.exists() &&
         currentTheme.locationType != EMBEDDED)
@@ -67,6 +63,22 @@ Utils::~Utils()
     if (config)
         config->saveIfNeeded();
     config = nullptr;
+}
+
+void Utils::loadFactoryBank()
+{
+    for (auto &b : bankLocations)
+    {
+        if (b.locationType == SYSTEM_FACTORY || b.locationType == LOCAL_FACTORY)
+        {
+            if (b.file.getFileName() == "Factory.fxb")
+            {
+                loadFromFXBFile(b.file);
+                return;
+            }
+        }
+    }
+    DBG("No factory bank found. Using all inits");
 }
 
 juce::File Utils::fsPathToJuceFile(const fs::path &p) const

--- a/src/Utils.h
+++ b/src/Utils.h
@@ -200,6 +200,8 @@ class Utils final
         hostUpdateCallback = std::move(callback);
     }
 
+    void loadFactoryBank();
+
     // callbacks
     std::function<bool(juce::MemoryBlock &, const int)> loadMemoryBlockCallback;
     std::function<void(juce::MemoryBlock &)> getStateInformationCallback;


### PR DESCRIPTION
The on-startup factory bank load happened before the processor had setup the callbacks and so on. So make an explicit loadFactoryBank method and call it at the end of the processor constructor.

Closes #466