### PR TITLE
Fix a copy paste crash; retain defensive code

### DIFF
--- a/src/PluginEditor.cpp
+++ b/src/PluginEditor.cpp
@@ -2768,13 +2768,13 @@ void ObxfAudioProcessorEditor::MenuActionCallback(int action)
     // Copy to clipboard
     if (action == MenuAction::CopyPatch)
     {
-        utils.copyPatch();
+        utils.copyPatch(processor.getCurrentBank().getCurrentProgramIndex());
     }
 
     // Paste from clipboard
     if (action == MenuAction::PastePatch)
     {
-        utils.pastePatch();
+        utils.pastePatch(processor.getCurrentBank().getCurrentProgramIndex());
     }
 
     if (action == MenuAction::RevealUserDirectory)

--- a/src/PluginProcessor.cpp
+++ b/src/PluginProcessor.cpp
@@ -208,7 +208,11 @@ bool ObxfAudioProcessor::producesMidi() const
 bool ObxfAudioProcessor::isMidiEffect() const { return false; }
 double ObxfAudioProcessor::getTailLengthSeconds() const { return 0.0; }
 int ObxfAudioProcessor::getNumPrograms() { return MAX_PROGRAMS; }
-int ObxfAudioProcessor::getCurrentProgram() { return currentBank.currentProgram; }
+int ObxfAudioProcessor::getCurrentProgram()
+{
+    assert(currentBank.hasCurrentProgram());
+    return currentBank.getCurrentProgramIndex();
+}
 
 void ObxfAudioProcessor::loadCurrentProgramParameters()
 {
@@ -239,7 +243,7 @@ void ObxfAudioProcessor::loadCurrentProgramParameters()
 
 void ObxfAudioProcessor::setCurrentProgram(const int index)
 {
-    currentBank.currentProgram = index;
+    currentBank.setCurrentProgram(index);
     isHostAutomatedChange = false;
 
     loadCurrentProgramParameters();
@@ -253,7 +257,7 @@ void ObxfAudioProcessor::setCurrentProgram(const int index)
 
 void ObxfAudioProcessor::setCurrentProgram(const int index, const bool updateHost)
 {
-    currentBank.currentProgram = index;
+    currentBank.setCurrentProgram(index);
     isHostAutomatedChange = false;
 
     loadCurrentProgramParameters();
@@ -436,10 +440,10 @@ void ObxfAudioProcessor::restoreCurrentProgramToOriginalState()
 {
     if (currentBank.getIsCurrentProgramDirty())
     {
-        currentBank.programs[currentBank.currentProgram.load()] =
-            currentBank.originalPrograms[currentBank.currentProgram.load()];
+        currentBank.programs[currentBank.getCurrentProgramIndex()] =
+            currentBank.originalPrograms[currentBank.getCurrentProgramIndex()];
         currentBank.setCurrentProgramDirty(false);
-        setCurrentProgram(currentBank.currentProgram.load());
+        setCurrentProgram(currentBank.getCurrentProgramIndex());
     }
 }
 
@@ -447,8 +451,8 @@ void ObxfAudioProcessor::saveCurrentProgramAsOriginalState()
 {
     if (currentBank.getIsCurrentProgramDirty())
     {
-        currentBank.originalPrograms[currentBank.currentProgram.load()] =
-            currentBank.programs[currentBank.currentProgram.load()];
+        currentBank.originalPrograms[currentBank.getCurrentProgramIndex()] =
+            currentBank.programs[currentBank.getCurrentProgramIndex()];
         currentBank.setCurrentProgramDirty(false);
     }
 }

--- a/src/PluginProcessor.h
+++ b/src/PluginProcessor.h
@@ -141,7 +141,7 @@ class ObxfAudioProcessor final : public juce::AudioProcessor,
 
     void updateProgramValue(const juce::String &paramId, float value) override
     {
-        if (currentBank.currentProgram >= 0 && currentBank.currentProgram < MAX_PROGRAMS)
+        if (currentBank.hasCurrentProgram())
         {
             currentBank.getCurrentProgram().values[paramId] = value;
         }
@@ -162,7 +162,10 @@ class ObxfAudioProcessor final : public juce::AudioProcessor,
     void saveAllFrontProgramsToBack();
     void saveSpecificFrontProgramToBack(int index);
 
-    int getCurrentPatchGroup() { return currentBank.currentProgram / NUM_PATCHES_PER_GROUP; }
+    int getCurrentPatchGroup()
+    {
+        return currentBank.getCurrentProgramIndex() / NUM_PATCHES_PER_GROUP;
+    }
 
     void randomizeToAlgo(RandomAlgos algo);
     void panSetter(PanAlgos alg);

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -549,15 +549,16 @@ void Utils::pastePatch(const int index)
     if (pastePatchCallback)
     {
         juce::MemoryBlock memoryBlock;
-        memoryBlock.fromBase64Encoding(juce::SystemClipboard::getTextFromClipboard());
-        pastePatchCallback(memoryBlock, index);
+        if (memoryBlock.fromBase64Encoding(juce::SystemClipboard::getTextFromClipboard()))
+            pastePatchCallback(memoryBlock, index);
     }
 }
 
 bool Utils::isPatchInClipboard()
 {
     juce::MemoryBlock memoryBlock;
-    memoryBlock.fromBase64Encoding(juce::SystemClipboard::getTextFromClipboard());
+    if (!memoryBlock.fromBase64Encoding(juce::SystemClipboard::getTextFromClipboard()))
+        return false;
 
     return isMemoryBlockAPatch(memoryBlock);
 }

--- a/src/Utils.h
+++ b/src/Utils.h
@@ -174,9 +174,8 @@ class Utils final
 
     std::function<void(juce::MemoryBlock &, const int)> pastePatchCallback;
 
-    // negative index means current patch!
-    void copyPatch(const int index = -1);
-    void pastePatch(const int index = -1);
+    void copyPatch(const int index);
+    void pastePatch(const int index);
 
     bool isPatchInClipboard();
 

--- a/src/engine/Bank.h
+++ b/src/engine/Bank.h
@@ -32,10 +32,16 @@ class Bank
 {
   public:
     Program programs[MAX_PROGRAMS], originalPrograms[MAX_PROGRAMS];
+
+  private:
     std::atomic<int> currentProgram{0};
+
+  public:
     std::array<bool, MAX_PROGRAMS> programDirty{};
 
     Bank() = default;
+
+    int getCurrentProgramIndex() const { return currentProgram.load(); }
 
     Program &getCurrentProgram()
     {
@@ -70,6 +76,10 @@ class Bank
     bool hasCurrentProgram() const
     {
         int idx = currentProgram.load();
+        if (idx < 0 || idx >= MAX_PROGRAMS)
+        {
+            DBG("Index is unforunately " << idx);
+        }
         return idx >= 0 && idx < MAX_PROGRAMS;
     }
 
@@ -77,6 +87,10 @@ class Bank
     {
         if (idx >= 0 && idx < MAX_PROGRAMS)
             currentProgram.store(idx);
+        else
+        {
+            DBG("Set current program to out of range " << idx);
+        }
     }
 };
 

--- a/src/state/StateManager.cpp
+++ b/src/state/StateManager.cpp
@@ -170,7 +170,7 @@ void StateManager::setStateInformation(const void *data, int sizeInBytes,
                          * of them is current so only one needs to notify the host
                          * of the param change.
                          */
-                        if (i == audioProcessor->getCurrentBank().currentProgram)
+                        if (i == audioProcessor->getCurrentBank().getCurrentProgramIndex())
                         {
                             param->beginChangeGesture();
                             param->setValueNotifyingHost(value);
@@ -228,7 +228,8 @@ void StateManager::setStateInformation(const void *data, int sizeInBytes,
 
         if (restoreCurrentProgram)
         {
-            audioProcessor->setCurrentProgram(audioProcessor->getCurrentBank().currentProgram);
+            audioProcessor->setCurrentProgram(
+                audioProcessor->getCurrentBank().getCurrentProgramIndex());
         }
 
         auto desp = xmlState->getChildByName(S("dawExtraState"));
@@ -282,7 +283,8 @@ void StateManager::setProgramStateInformation(const void *data, const int sizeIn
         }
 
         if (index < 0 || idx == audioProcessor->getCurrentProgram())
-            audioProcessor->setCurrentProgram(audioProcessor->getCurrentBank().currentProgram);
+            audioProcessor->setCurrentProgram(
+                audioProcessor->getCurrentBank().getCurrentProgramIndex());
 
         sendChangeMessage();
     }


### PR DESCRIPTION
1. Fix a copy/paste bug where copy/paste through the main menu would crash (but it was fine on the programmer buttons). This fix is using curent program in the menu callback in editor.
2. In doing so I just generally upped some of the defensiveness of the code while debugging, so retain that.