### PR TITLE
MIDI Event time error

### DIFF
--- a/src/PluginProcessor.cpp
+++ b/src/PluginProcessor.cpp
@@ -135,7 +135,7 @@ void ObxfAudioProcessor::processBlock(juce::AudioBuffer<float> &buffer,
     }
 
     auto it = midiMessages.begin();
-    const bool hasMidiMessage = (it != midiMessages.end());
+    bool hasMidiMessage = (it != midiMessages.end());
 
     synth.getMotherboard()->tuning.updateMTSESPStatus();
 
@@ -144,12 +144,15 @@ void ObxfAudioProcessor::processBlock(juce::AudioBuffer<float> &buffer,
         if (hasMidiMessage)
         {
             midiHandler.processMidiPerSample(&it, midiMessages, samplePos);
+            hasMidiMessage = (it != midiMessages.end());
         }
         midiHandler.processLags();
 
         synth.processSample(channelData1 + samplePos, channelData2 + samplePos);
         ++samplePos;
     }
+
+    assert(!hasMidiMessage);
 
     if (uiState.editorAttached)
     {

--- a/src/midi/MidiHandler.cpp
+++ b/src/midi/MidiHandler.cpp
@@ -219,17 +219,13 @@ bool MidiHandler::getNextEvent(juce::MidiBufferIterator *iter, const juce::MidiB
     if (iter == nullptr || *iter == midiBuffer.end())
         return false;
 
-    while (*iter != midiBuffer.end())
+    if (const auto metadata = **iter;
+        metadata.samplePosition <= samplePos && metadata.getMessage().getRawDataSize() > 0)
     {
-        if (const auto metadata = **iter;
-            metadata.samplePosition >= samplePos && metadata.getMessage().getRawDataSize() > 0)
-        {
-            *midiMsg = metadata.getMessage();
-            midiEventPos = metadata.samplePosition;
-            ++(*iter);
-            return true;
-        }
+        *midiMsg = metadata.getMessage();
+        midiEventPos = metadata.samplePosition;
         ++(*iter);
+        return true;
     }
     return false;
 }


### PR DESCRIPTION
The midi event handling for all midi events pushed them to block position 0. Make it so we actually obey the sample time on the midi event.

This was especially noticable in Logic which uses long block sizes for unselected unrecord armed tracks during playback.