### PR TITLE
Avoid redundant automation data

### DIFF
--- a/src/PluginProcessor.cpp
+++ b/src/PluginProcessor.cpp
@@ -234,9 +234,13 @@ void ObxfAudioProcessor::loadCurrentProgramParameters()
                 const float value =
                     (it != prog.values.end()) ? it->second.load() : param->meta.defaultVal;
 
-                param->beginChangeGesture();
-                param->setValueNotifyingHost(value);
-                param->endChangeGesture();
+                auto v = param->convertTo0to1(param->get());
+                if (v != value)
+                {
+                    param->beginChangeGesture();
+                    param->setValueNotifyingHost(value);
+                    param->endChangeGesture();
+                }
             }
         }
     }
@@ -246,6 +250,9 @@ void ObxfAudioProcessor::loadCurrentProgramParameters()
 
 void ObxfAudioProcessor::setCurrentProgram(const int index)
 {
+    if (index == currentBank.getCurrentProgramIndex())
+        return;
+
     currentBank.setCurrentProgram(index);
     isHostAutomatedChange = false;
 


### PR DESCRIPTION
when patch changed redundant automation data would get sent to the UI. This happened for a few reasons, but specifically it happened because on UI show the on-change message for the programmer button fired setting the current program to the current program which triggered a full reval on ui open. Not what we want.

So do a couple of things

1. Set current program(current program) is a no-op. Since StateManager also does an explicit flush to host on state load this should be safe
2. If a value of a param hasn't changed in program change, dont send it

Closes #471