### PR TITLE
Move the patch change protection guard a bit

### DIFF
--- a/src/PluginEditor.cpp
+++ b/src/PluginEditor.cpp
@@ -1360,8 +1360,18 @@ void ObxfAudioProcessorEditor::createComponentsFromXml(const juce::XmlElement *d
                 patchNumberMenu->onChange = [safeThis]() {
                     if (!safeThis)
                         return;
-                    safeThis->processor.setCurrentProgram(
-                        safeThis->patchNumberMenu->getSelectedId() - 1);
+                    /*
+                     * juce::ComboBox calls onChange at construction time fo this menu
+                     * it seems, when we set the combo box display value. But we dont
+                     * want to force a fire if theres no actual change. See #471
+                     */
+                    auto dpn = safeThis->patchNumberMenu->getSelectedId() - 1;
+                    auto cpn = safeThis->processor.getCurrentProgram();
+                    if (dpn == cpn)
+                    {
+                        return;
+                    }
+                    safeThis->processor.setCurrentProgram(dpn);
                     safeThis->needNotifyToHost = true;
                     safeThis->countTimer = 0;
                 };

--- a/src/PluginProcessor.cpp
+++ b/src/PluginProcessor.cpp
@@ -250,9 +250,7 @@ void ObxfAudioProcessor::loadCurrentProgramParameters()
 
 void ObxfAudioProcessor::setCurrentProgram(const int index)
 {
-    if (index == currentBank.getCurrentProgramIndex())
-        return;
-
+    DBG("setCurrentProgram " << index);
     currentBank.setCurrentProgram(index);
     isHostAutomatedChange = false;
 


### PR DESCRIPTION
in  8966ad I made setCurrentProgram not work if the index is unchanged. On reflection overnight I moved the protection to where the root cause of the #471 problem is (but kept the value change onguard in the params)

Just a bit more of a conserative approach to the same fix