### PR TITLE
Small change to zoom menu

### DIFF
--- a/src/PluginEditor.cpp
+++ b/src/PluginEditor.cpp
@@ -2536,8 +2536,10 @@ void ObxfAudioProcessorEditor::createMenu()
                 true);
         }
 
-        if (utils.getDefaultZoomFactor() != curZoom)
+        // used to be an if - change to show it non-enabled
+        // if (utils.getDefaultZoomFactor() != curZoom)
         {
+            auto disp = (utils.getDefaultZoomFactor() != curZoom);
             auto dispZoom = curZoom;
 
             if (isCurZoomAmongScaleFactors)
@@ -2548,7 +2550,7 @@ void ObxfAudioProcessorEditor::createMenu()
             sizeMenu.addItem(
                 toOSCase(fmt::format("Set {:.{}f}% as Default Zoom Level", dispZoom * 100.f,
                                      isCurZoomAmongScaleFactors ? 0 : 1)),
-                [this, curZoom]() { utils.setDefaultZoomFactor(curZoom); });
+                disp, false, [this, curZoom]() { utils.setDefaultZoomFactor(curZoom); });
         }
 
         menu->addSubMenu("Zoom", sizeMenu);


### PR DESCRIPTION
Some users were reporting 'zoom doesn't stick'. This is because the menu was a bit confusing and zoom is transient zoom not default zoom. So i wondered why they didn't set the new zoom as default and realized because the menu option to do so doesn't show if you are on the default zoom. So you don't know you have to revisit to set the default.

Two things we can do

1. All zoom changes update the default. Big change
2. Keep the default menu there but not enabled if you are on default so user knows they may have to set it after change

I chose 2. We can go to 1 or anything else but this will at least squash an intermediate confusion