### PR TITLE
Store current program in the DAW streamed state

### DIFF
--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -28,6 +28,14 @@
 
 Utils::Utils() : configLock("__" JucePlugin_Name "ConfigLock__")
 {
+#if DEBUG
+    if (fromHumanReadableVersion(humanReadableVersion(currentStreamingVersion)) !=
+        currentStreamingVersion)
+    {
+        throw std::runtime_error("Invalid version number conversion");
+    }
+#endif
+
     createDocumentFolderIfMissing();
     resolveFactoryFolderInUse();
 

--- a/src/Utils.h
+++ b/src/Utils.h
@@ -42,11 +42,21 @@ inline static float logsc(float param, const float min, const float max, const f
     return ((expf(param * logf(rolloff + 1.f)) - 1.f) / (rolloff)) * (max - min) + min;
 }
 
-static constexpr uint64_t currentStreamingVersion{0x2025'06'24};
+static constexpr uint64_t currentStreamingVersion{0x2025'11'14};
 
 inline std::string humanReadableVersion(const uint64_t v)
 {
     return fmt::format("{:04x}-{:02x}-{:02x}", (v >> 16) & 0xFFFF, (v >> 8) & 0xFF, v & 0xFF);
+}
+
+inline uint64_t fromHumanReadableVersion(const std::string &v)
+{
+    if (v.size() != 10)
+        return 0;
+    if (v[4] != '-' && v[7] != '-')
+        return 0;
+    return std::stoul(v.substr(0, 4), nullptr, 16) << 16 |
+           std::stoul(v.substr(5, 2), nullptr, 16) << 8 | std::stoul(v.substr(8, 2), nullptr, 16);
 }
 
 class Utils final


### PR DESCRIPTION
Store current program in DAW state and presets. Closes #440.

This leaves a few other unstream with ui problems though around the multi-state button triggering the dirty state with a callback having to do with the attachment having a notification wrong. I'm going to fix that (hopefully) in a separate commit.