### PR TITLE
Fix a plugin-params problem when loading

### DIFF
--- a/src/state/StateManager.cpp
+++ b/src/state/StateManager.cpp
@@ -181,7 +181,8 @@ void StateManager::setStateInformation(const void *data, int sizeInBytes,
                          * of them is current so only one needs to notify the host
                          * of the param change. But only do this for the front program
                          */
-                        if (progNode == S("programs") && i == audioProcessor->getCurrentBank().getCurrentProgramIndex())
+                        if (progNode == S("programs") &&
+                            i == audioProcessor->getCurrentBank().getCurrentProgramIndex())
                         {
                             param->beginChangeGesture();
                             param->setValueNotifyingHost(value);


### PR DESCRIPTION
When loading a dual settings into a running session (or even in some cases a new session) the orig not the front program set the params which could confuse the heck out of daws

This should resolve the issues reporte din logic

Addresses #477

Waiting for user feedback to close