### PR TITLE
Logic load sequence and FIFO slop fix

### DIFF
--- a/src/PluginProcessor.cpp
+++ b/src/PluginProcessor.cpp
@@ -219,7 +219,11 @@ int ObxfAudioProcessor::getCurrentProgram()
 
 void ObxfAudioProcessor::loadCurrentProgramParameters()
 {
-    paramAdapter->clearFIFO();
+    if (!paramAdapter->isFIFOClear())
+    {
+        juce::Timer::callAfterDelay(50, [this]() { loadCurrentProgramParameters(); });
+        return;
+    }
 
     paramAdapter->getParameterManager().setSupressGestureToDirty(true);
     if (currentBank.hasCurrentProgram())

--- a/src/parameter/FIFO.h
+++ b/src/parameter/FIFO.h
@@ -59,6 +59,7 @@ template <size_t Capacity> class FIFO
     FIFO() : abstractFIFO{Capacity} {}
 
     void clear() { abstractFIFO.reset(); }
+    bool isClear() { return abstractFIFO.getNumReady() == 0; }
 
     size_t getFreeSpace() const { return abstractFIFO.getFreeSpace(); }
 

--- a/src/parameter/ParameterAdapter.h
+++ b/src/parameter/ParameterAdapter.h
@@ -97,6 +97,7 @@ class ParameterManagerAdapter
     void updateParameters(bool force = false) { paramManager.updateParameters(force); }
 
     void clearFIFO() { paramManager.clearFiFO(); }
+    bool isFIFOClear() { return paramManager.isFiFOClear(); }
 
     ParameterManager &getParameterManager() { return paramManager; }
     const ParameterManager &getParameterManager() const { return paramManager; }

--- a/src/parameter/ParameterManager.cpp
+++ b/src/parameter/ParameterManager.cpp
@@ -146,7 +146,7 @@ void ParameterManager::updateParameters(const bool force)
                                   cb(value, true);
                           }
                       });
-        fifo.clear();
+        // fifo.clear();
         // DBG("Force updated all parameters: " + processedParams);
     }
 
@@ -243,3 +243,5 @@ void ParameterManager::parameterGestureChanged(int, bool)
         audioProcessor.setCurrentProgramDirtyState(true);
     }
 }
+
+bool ParameterManager::isFiFOClear() { return fifo.isClear(); }

--- a/src/parameter/ParameterManager.h
+++ b/src/parameter/ParameterManager.h
@@ -57,6 +57,7 @@ class ParameterManager : public juce::AudioProcessorParameter::Listener
     void flushParameterQueue();
 
     void clearFiFO() { fifo.clear(); }
+    bool isFiFOClear();
 
     void updateParameters(bool force = false);
 


### PR DESCRIPTION
Our use of the FIFO assumed it was 'always drained' in a couple of spots and that meant in the logic pro (correct) load sequence that assumption failed us. So we would apply partial or incomplete states and have all sorts of other nasties.

This does two things

1. On a force load, still process the fifo if outstanding for callbacks so when prepareToPlay interacts with a load still going on we dont drop the load and
2. In the UI side loadCurrentProgram which updates all the params if there's still unprocessed fifo kicking around, defer the loadCurrent until that queue is all clear.

Should address #477