### PR TITLE
Apply init patch in prev/next program callback

### DIFF
--- a/src/PluginEditor.cpp
+++ b/src/PluginEditor.cpp
@@ -2687,6 +2687,7 @@ void ObxfAudioProcessorEditor::nextProgram()
     if (nlp < 0)
     {
         utils.initializePatch();
+        processor.processActiveProgramChanged();
     }
     else
     {
@@ -2705,6 +2706,7 @@ void ObxfAudioProcessorEditor::prevProgram()
     if (nlp == -1)
     {
         utils.initializePatch();
+        processor.processActiveProgramChanged();
     }
     else
     {


### PR DESCRIPTION
We initalized the patch but didn't update the engine.

Closes #501