### PR TITLE
Reinstate integer-style menus for patch menu

### DIFF
--- a/src/PluginEditor.cpp
+++ b/src/PluginEditor.cpp
@@ -1382,7 +1382,10 @@ void ObxfAudioProcessorEditor::createComponentsFromXml(const juce::XmlElement *d
 
                 juce::PopupMenu m;
                 safeThis->createPatchList(m);
-                m.showMenuAsync(juce::PopupMenu::Options());
+                m.showMenuAsync(juce::PopupMenu::Options(), [safeThis](int i) {
+                    if (safeThis)
+                        safeThis->MenuActionCallback(i);
+                });
             };
             componentMap[name] = patchNumberMenu.get();
             addChildComponent(*patchNumberMenu);


### PR DESCRIPTION
Since it was mostly lambda menus we didn't need to bind the callback but a few legacy ones still were there so hook up