### PR TITLE
Fix a retrigger-completed-envelope linear issue

### DIFF
--- a/src/engine/AdsrEnvelope.h
+++ b/src/engine/AdsrEnvelope.h
@@ -171,6 +171,10 @@ class ADSREnvelope
             output = fudgeE * x;
             outputLin = fudgeL * x;
         }
+        else
+        {
+            outputLin = 0.f;
+        }
     }
 
     void updateAttackCoeff()


### PR DESCRIPTION
When retriggering a playing envelope we are careful to set outputLin appropriately but if the envelope has finished and retriggers - which the filter envelope can if it has a shorter release than the AEG - the outputLin didn't re-synch to zero.

Fix

Closes #493