### PR TITLE
A few MIDI learn UX improvements

### DIFF
--- a/src/PluginEditor.h
+++ b/src/PluginEditor.h
@@ -175,7 +175,6 @@ class ObxfAudioProcessorEditor final : public juce::AudioProcessorEditor,
     void keyboardFocusMainMenu();
 
     void randomizeCallback();
-    bool isValidMidiCC(int cc);
 
   public:
     void idle();

--- a/src/PluginProcessor.cpp
+++ b/src/PluginProcessor.cpp
@@ -67,9 +67,9 @@ void ObxfAudioProcessor::prepareToPlay(const double sampleRate, const int /*samp
 {
     midiHandler.prepareToPlay();
 
-    paramCoordinator->getParameterUpdateHandler().setSupressGestureToUndo(true);
+    paramCoordinator->getParameterUpdateHandler().setSuppressGestureToUndo(true);
     paramCoordinator->getParameterUpdateHandler().updateParameters(true);
-    paramCoordinator->getParameterUpdateHandler().setSupressGestureToUndo(false);
+    paramCoordinator->getParameterUpdateHandler().setSuppressGestureToUndo(false);
 
     synth.setSampleRate(static_cast<float>(sampleRate));
     midiHandler.setSampleRate(sampleRate);
@@ -249,7 +249,7 @@ void ObxfAudioProcessor::applyActiveProgramValuesToJUCEParameters()
         return;
     }
 
-    paramCoordinator->getParameterUpdateHandler().setSupressGestureToUndo(true);
+    paramCoordinator->getParameterUpdateHandler().setSuppressGestureToUndo(true);
     const Program &prog = activeProgram;
     for (auto *param : ObxfParams(*this))
     {
@@ -270,7 +270,7 @@ void ObxfAudioProcessor::applyActiveProgramValuesToJUCEParameters()
         }
     }
 
-    paramCoordinator->getParameterUpdateHandler().setSupressGestureToUndo(false);
+    paramCoordinator->getParameterUpdateHandler().setSuppressGestureToUndo(false);
 }
 
 void ObxfAudioProcessor::processActiveProgramChanged()
@@ -284,20 +284,20 @@ void ObxfAudioProcessor::sendChangeMessageWithUndoSuppressed()
     if (juce::MessageManager::existsAndIsCurrentThread())
     {
         // we can trigger the listeners synchronously
-        paramCoordinator->getParameterUpdateHandler().setSupressGestureToUndo(true);
+        paramCoordinator->getParameterUpdateHandler().setSuppressGestureToUndo(true);
         sendSynchronousChangeMessage();
-        paramCoordinator->getParameterUpdateHandler().setSupressGestureToUndo(false);
+        paramCoordinator->getParameterUpdateHandler().setSuppressGestureToUndo(false);
     }
     else
     {
         // We know the message queue is ordered so this should toggle
         // around the send change message.
         juce::MessageManager::callAsync([this]() {
-            paramCoordinator->getParameterUpdateHandler().setSupressGestureToUndo(true);
+            paramCoordinator->getParameterUpdateHandler().setSuppressGestureToUndo(true);
         });
         sendChangeMessage();
         juce::MessageManager::callAsync([this]() {
-            paramCoordinator->getParameterUpdateHandler().setSupressGestureToUndo(false);
+            paramCoordinator->getParameterUpdateHandler().setSuppressGestureToUndo(false);
         });
     }
 }
@@ -329,10 +329,10 @@ void ObxfAudioProcessor::getStateInformation(juce::MemoryBlock &destData)
 
 void ObxfAudioProcessor::setStateInformation(const void *data, const int sizeInBytes)
 {
-    paramCoordinator->getParameterUpdateHandler().setSupressGestureToUndo(true);
+    paramCoordinator->getParameterUpdateHandler().setSuppressGestureToUndo(true);
     state->setPluginStateInformation(data, sizeInBytes);
     state->applyDAWExtraStateToInstance();
-    paramCoordinator->getParameterUpdateHandler().setSupressGestureToUndo(false);
+    paramCoordinator->getParameterUpdateHandler().setSuppressGestureToUndo(false);
 
     auto pn = activeProgram.getName();
     if (pn.isEmpty())

--- a/src/midi/MidiHandler.cpp
+++ b/src/midi/MidiHandler.cpp
@@ -52,11 +52,11 @@ struct MidiHandler::LagHandler
     {
         // Notify host when done or when snapped
         auto &uh = handler.paramCoordinator.getParameterUpdateHandler();
-        uh.setSupressGestureToUndo(true);
+        uh.setSuppressGestureToUndo(true);
         handler.paramCoordinator.setEngineParameterValue(
             handler.synth, handler.bindings.getParamID(index), lags[index].lag.v, true);
         uh.updateParameters(false);
-        uh.setSupressGestureToUndo(false);
+        uh.setSuppressGestureToUndo(false);
     }
 };
 
@@ -165,9 +165,6 @@ void MidiHandler::processMidiPerSample(juce::MidiBufferIterator *iter,
                     midiControlledParamSet = true;
 
                     bindings.updateCC(lastUsedParameter, lastMovedController);
-
-                    paramCoordinator.midiLearnAttachment.set(false);
-                    lastUsedParameter = 0;
                 }
 
                 if (bindings.isBound(lastMovedController))

--- a/src/parameter/ParameterUpdateHandler.h
+++ b/src/parameter/ParameterUpdateHandler.h
@@ -86,7 +86,7 @@ class ParameterUpdateHandler : public juce::AudioProcessorParameter::Listener
     juce::RangedAudioParameter *getParameter(const juce::String &paramID) const;
     void addParameter(const juce::String &paramID, juce::RangedAudioParameter *param);
 
-    void setSupressGestureToUndo(bool state) { supressGestureToUndo = state; }
+    void setSuppressGestureToUndo(bool state) { supressGestureToUndo = state; }
     void undo();
     // TODO: Redo
     void redo();


### PR DESCRIPTION
Show overlays for all learnable parameters at once.

Don't bail out of MIDI learn mode after learning one control, allow reselecting a different parameter to learn it more quickly.

Don't show overlays for parameters that are not currently visible (TODO: this needs to be refreshed when tabbing between LFOs or filter pole/Xpander modes!).

Some cleanup of unused methods.

Adjusted positioning of MIDI learn overlays for almost all parameters.

Addresses #334.