### PR TITLE
Fix a setCurrentFrame repaint issue

### DIFF
--- a/src/gui/Label.h
+++ b/src/gui/Label.h
@@ -66,7 +66,7 @@ class Label final : public juce::Component, public HasScaleFactor
 
     void setCurrentFrame(int frameIndex)
     {
-        auto nextFrame  = juce::jlimit(0, totalFrames - 1, frameIndex);
+        auto nextFrame = juce::jlimit(0, totalFrames - 1, frameIndex);
         if (nextFrame != currentFrame)
         {
             currentFrame = nextFrame;


### PR DESCRIPTION
setCurrentFrame on a label would repaint even if the frame wasnt changed. Since we sweep bank labels in idle, this would result in a repaint every idle.

Fix