### PR TITLE
Fix a crash on editor destroy while automating

### DIFF
--- a/src/parameter/ParameterAttachment.h
+++ b/src/parameter/ParameterAttachment.h
@@ -93,7 +93,7 @@ template <typename Control, bool beginEditFromDrag> class Attachment
             juce::MessageManager::callAsync([cwp, that = this, value]() {
                 if (!cwp)
                 {
-                    // In between the message getting generated and now the c9ntrol has gone
+                    // In between the message getting generated and now the control has gone
                     // away on screen either from editor closing or from ui having some
                     // other transformation or rebuild.
                     return;


### PR DESCRIPTION
involving mismatched lifecycles

Closes #540