### PR TITLE
Downsample the LFO

### DIFF
--- a/src/engine/Lfo.h
+++ b/src/engine/Lfo.h
@@ -186,8 +186,9 @@ class LFO
                 state.wave.samplehold = state.rng.nextFloat() * 2.f - 1.f;
             }
 
-            if (phaseOnly) // the phase only case helps us a little for silent synth case
-                return;
+            if constexpr (blockFactor == 1)
+                if (phaseOnly)
+                    return;
 
             // casting dance is to satisfy MSVC Clang
             state.wave.sine =
@@ -201,6 +202,13 @@ class LFO
                 state.wave.history +
                 (state.wave.samplehold - state.wave.history) * (pi + state.phase) * invTwoPi;
             recalculateBlockTarget();
+
+            if (phaseOnly)
+            {
+                // phase only used to mean just advance phase but with the onset of block processing
+                // we still make the intermediates just we assume no smoother is called so
+                state.smoothedOutput = state.blockTarget;
+            }
         }
         else
         {


### PR DESCRIPTION
Since the LFO already runs through a 250hz LPF for smoothing there's really no need to calculate everything on every sample. This introcuces a downsampling block factor for recalculating the target the LPF chases and sets it to 8 samples, which is 5k at 44.1 well above the LPF

It also basically removes the LPF from profiling runs of high poly cases.