### PR TITLE
Remove mouse drag velocity sensitivity on Shift

### DIFF
--- a/src/gui/Knob.h
+++ b/src/gui/Knob.h
@@ -191,7 +191,7 @@ class Knob final : public juce::Slider,
         numFr = kni.getHeight() / h2;
 
         setLookAndFeel(&lookAndFeel);
-        setVelocityModeParameters(0.25, 1, 0.0, true, juce::ModifierKeys::shiftModifier);
+        setVelocityModeParameters(0.1, 1, 0.1, true, juce::ModifierKeys::shiftModifier);
     }
 
     ~Knob() override { setLookAndFeel(nullptr); }


### PR DESCRIPTION
...by setting the offset value the same as sensitivity value in setVelocityModeParameters(). Also dropped sensitivity down to 0.1, from 0.25.

I tested this with Surge XT mouse behavior set to Slow (which on Windows I find perfectly natural) and it's pretty much feeling about the same.

Consider adding mouse behavior options as far as speed is concerned, later.

Closes #569