### PR TITLE
Init from DAW works now

### DIFF
--- a/src/PluginProcessor.cpp
+++ b/src/PluginProcessor.cpp
@@ -227,6 +227,7 @@ void ObxfAudioProcessor::setCurrentProgram(const int index)
     if (index == 0)
     {
         utils->initializePatch();
+        processActiveProgramChanged();
     }
     else
     {


### PR DESCRIPTION
before it partially applied the init patch, which is a different path than loadPatch(file)

Closes #571