### PR TITLE
Clicking on patch name also opens the browser

### DIFF
--- a/src/PluginEditor.cpp
+++ b/src/PluginEditor.cpp
@@ -594,14 +594,21 @@ void ObxfAudioProcessorEditor::createComponentsFromXml(const juce::XmlElement *d
             patchNameLabel->setColour(juce::CaretComponent::caretColourId, juce::Colours::red);
 
             patchNameLabel->setVisible(true);
+            patchNameLabel->setEditable(false);
 
             addChildComponent(*patchNameLabel);
 
             auto safeThis = SafePointer(this);
-            patchNameLabel->onTextChange = [safeThis]() {
+            patchNameLabel->onClick = [safeThis]() {
                 if (!safeThis)
                     return;
-                safeThis->processor.getActiveProgram().setName(safeThis->patchNameLabel->getText());
+
+                juce::PopupMenu m;
+                safeThis->createPatchList(m);
+                m.showMenuAsync(juce::PopupMenu::Options(), [safeThis](int i) {
+                    if (safeThis)
+                        safeThis->MenuActionCallback(i);
+                });
             };
 
             componentMap[name] = patchNameLabel.get();

--- a/src/gui/Display.h
+++ b/src/gui/Display.h
@@ -38,6 +38,14 @@ class Display final : public juce::Label
         setEditable(true);
     }
 
+    std::function<void()> onClick{nullptr};
+
+    void mouseDown(const juce::MouseEvent &event) override
+    {
+        if (!isEditable() && onClick)
+            onClick();
+    }
+
     void editorShown(juce::TextEditor *editor) override
     {
         // sigh, JUCE, you could've fixed this for the label's editor in the past 10 years...


### PR DESCRIPTION
Since we have the patch name field in the Save Patch dialog, there's no real need having it repeated on the main GUI when renaming the patch doesn't get saved immediately.