### PR TITLE
Avoid a spurious param notifcation on UI open

### DIFF
--- a/src/PluginEditor.cpp
+++ b/src/PluginEditor.cpp
@@ -2276,7 +2276,7 @@ std::unique_ptr<Knob> ObxfAudioProcessorEditor::addKnob(int x, int y, int w, int
         if (auto *param = paramCoordinator.getParameter(paramId); param != nullptr)
         {
             knob->setParameter(param);
-            knob->setValue(param->getValue());
+            knob->setValue(param->getValue(), juce::dontSendNotification);
             knobAttachments.emplace_back(
                 new KnobAttachment(paramCoordinator.getParameterUpdateHandler(), param, *knob));
         }


### PR DESCRIPTION
When the UI opened someone called knob->setValue without a dont notify, which sent a spew of unguarded param set values to the host when the UI opens

I have a hunch that this is whats causing #542, but I can't figure out FL for the life of me, so I'll merge and ask Vincey or Evil to check!