### PR TITLE
Use the theme/skin for save dialog construction, if available

### DIFF
--- a/assets/binary/VectorTheme/theme.xml
+++ b/assets/binary/VectorTheme/theme.xml
@@ -276,7 +276,7 @@ However, if you omit the "pic" argument everywhere, the theme will still work be
     <widget name="savePatchDialog"                             w="246" h="328"                pic="label-bg-save-patch" />
     <widget name="savePatchNameLabel"         x="22"   y="29"  w="200" h="31"                                           />
     <widget name="savePatchAuthorLabel"       x="22"   y="90"  w="200" h="31"                                           />
-    <widget name="savePatchProjectLabel"      x="22"   y="90"  w="200" h="31"                                           />
+    <widget name="savePatchProjectLabel"      x="22"   y="151" w="200" h="31"                                           />
     <widget name="savePatchCategoryMenu"      x="25"   y="212" w="90"  h="31"                                           />
     <widget name="savePatchLicenseLabel"      x="126"  y="212" w="96"  h="31"                                           />
     <widget name="savePatchOKButton"          x="92"   y="272" w="23"  h="35"                                           />

--- a/src/PluginEditor.cpp
+++ b/src/PluginEditor.cpp
@@ -221,6 +221,9 @@ void ObxfAudioProcessorEditor::resized()
     {
         static FocusOrder focusOrder;
 
+        if (saveDialog)
+            saveDialog->resetState();
+
         for (const auto *child : cachedThemeXml->getChildWithTagNameIterator("widget"))
         {
             juce::String name = child->getStringAttribute("name");
@@ -230,6 +233,11 @@ void ObxfAudioProcessorEditor::resized()
             const auto w = child->getIntAttribute("w");
             const auto h = child->getIntAttribute("h");
             const auto d = child->getIntAttribute("d");
+
+            if (name.startsWith("savePatch") && saveDialog)
+            {
+                saveDialog->boundsMap[name.toStdString()] = juce::Rectangle<int>(x, y, w, h);
+            }
 
             if (componentMap[name] != nullptr)
             {
@@ -316,6 +324,9 @@ void ObxfAudioProcessorEditor::resized()
                 OBLOG(themes, "Null component map for " << name);
             }
         }
+
+        if (saveDialog)
+            saveDialog->resized();
     }
 
     const float sf = impliedScaleFactor();


### PR DESCRIPTION
The theme/skin can specify assets and so forth for the save dialog and coordinates as well.

Closes #530