### PR TITLE
Avoid a crash when the assets list is empty

### DIFF
--- a/src/PluginEditor.cpp
+++ b/src/PluginEditor.cpp
@@ -3295,7 +3295,7 @@ void ObxfAudioProcessorEditor::loadPatchFromProgrammer(int whichButton)
     {
         newIdx *= gsb ? NUM_PATCHES_PER_GROUP : 1;
 
-        if (newIdx >= 0 && newIdx < utils.patchesAsLinearList.size())
+        if (newIdx >= 0 && newIdx < (int)utils.patchesAsLinearList.size())
         {
             utils.loadPatch(utils.patchesAsLinearList[newIdx]);
         }


### PR DESCRIPTION
In the event of no assets we would still try and load patch zero with programmer buttons, leading to a crash

Closes #587