### PR TITLE
Fixes menu UI scaling (#529)

### DIFF
--- a/src/PluginEditor.cpp
+++ b/src/PluginEditor.cpp
@@ -27,6 +27,7 @@
 #include "components/ScalingImageCache.h"
 
 #include "gui/AboutScreen.h"
+#include "gui/PopupMenuScale.h"
 #include "gui/SaveDialog.h"
 #include "gui/FocusDebugger.h"
 #include "gui/FocusOrder.h"
@@ -1486,10 +1487,21 @@ void ObxfAudioProcessorEditor::createComponentsFromXml(const juce::XmlElement *d
 
                 juce::PopupMenu m;
                 safeThis->createPatchList(m);
-                m.showMenuAsync(juce::PopupMenu::Options(), [safeThis](int i) {
-                    if (safeThis)
-                        safeThis->MenuActionCallback(i);
-                });
+                const float scale = safeThis->impliedScaleFactor();
+                obxf::PopupMenuScale::set(scale);
+                const int itemHeight = juce::jmax(1, juce::roundToInt(22.f * scale));
+                const auto mousePos = juce::Desktop::getInstance().getMousePosition();
+                m.showMenuAsync(
+                    juce::PopupMenu::Options()
+                        .withTargetScreenArea(
+                            juce::Rectangle<int>(mousePos.getX(), mousePos.getY(), 1, 1))
+                        .withPreferredPopupDirection(
+                            juce::PopupMenu::Options::PopupDirection::upwards)
+                        .withStandardItemHeight(itemHeight),
+                    [safeThis](int i) {
+                        if (safeThis)
+                            safeThis->MenuActionCallback(i);
+                    });
             };
             componentMap[name] = patchNumberMenu.get();
             addChildComponent(*patchNumberMenu);
@@ -2824,9 +2836,16 @@ void ObxfAudioProcessorEditor::resultFromMenu(const juce::Point<int> pos)
 {
     createMenu();
 
+    const float scale = impliedScaleFactor();
+    obxf::PopupMenuScale::set(scale);
+    const int itemHeight = juce::jmax(1, juce::roundToInt(22.f * scale));
+
     popupMenus[0]->showMenuAsync(
-        juce::PopupMenu::Options().withTargetScreenArea(
-            juce::Rectangle<int>(pos.getX(), pos.getY(), 1, 1)),
+        juce::PopupMenu::Options()
+            .withTargetComponent(this)
+            .withTargetScreenArea(
+                juce::Rectangle<int>(pos.getX(), pos.getY(), 1, 1))
+            .withStandardItemHeight(itemHeight),
         [this](size_t result) {
             if (result >= (themeStart + 1) && result <= (themeStart + themes.size()))
             {
@@ -3083,6 +3102,8 @@ void ObxfAudioProcessorEditor::paintMissingAssets(juce::Graphics &g)
 
 void ObxfAudioProcessorEditor::paint(juce::Graphics &g)
 {
+    obxf::PopupMenuScale::set(impliedScaleFactor());
+
     if (noThemesAvailable)
     {
         paintMissingAssets(g);
@@ -3245,7 +3266,14 @@ void ObxfAudioProcessorEditor::randomizeCallback()
                         w->processor.randomizeToAlgo(alg);
                 });
         }
-        m.showMenuAsync(juce::PopupMenu::Options().withParentComponent(this));
+        const float scale = impliedScaleFactor();
+        obxf::PopupMenuScale::set(scale);
+        const int itemHeight = juce::jmax(1, juce::roundToInt(22.f * scale));
+        m.showMenuAsync(
+            juce::PopupMenu::Options()
+                .withTargetComponent(this)
+                .withParentComponent(this)
+                .withStandardItemHeight(itemHeight));
     }
     else
     {

--- a/src/gui/ButtonList.h
+++ b/src/gui/ButtonList.h
@@ -28,6 +28,7 @@
 #include "../src/engine/SynthEngine.h"
 #include "../components/ScalingImageCache.h"
 #include "HasScaleFactor.h"
+#include "PopupMenuScale.h"
 
 class ButtonListLookAndFeel final : public juce::LookAndFeel_V4
 {
@@ -39,13 +40,26 @@ class ButtonListLookAndFeel final : public juce::LookAndFeel_V4
         setColour(juce::ComboBox::textColourId, juce::Colours::transparentBlack);
     }
 
+    juce::Font getPopupMenuFont() override
+    {
+        auto f = juce::LookAndFeel_V4::getPopupMenuFont();
+        const float scale = obxf::PopupMenuScale::get();
+        if (scale != 1.f)
+            return f.withHeight(f.getHeight() * scale);
+        return f;
+    }
+
     juce::PopupMenu::Options getOptionsForComboBoxPopupMenu(juce::ComboBox &b, juce::Label &l)
     {
         // this is a huge hack to make sure our patch list menu draws fully on screen without being
         // clipped it's ugly but I'm fine with it because we're not gonna have a ButtonList that has
         // more entries than this
-        return juce::LookAndFeel_V4::getOptionsForComboBoxPopupMenu(b, l).withItemThatMustBeVisible(
-            MAX_PROGRAMS);
+        const float scale = obxf::PopupMenuScale::get();
+        const int itemHeight = juce::jmax(1, juce::roundToInt(22.f * scale));
+        return juce::LookAndFeel_V4::getOptionsForComboBoxPopupMenu(b, l)
+            .withTargetComponent(&b)
+            .withStandardItemHeight(itemHeight)
+            .withItemThatMustBeVisible(MAX_PROGRAMS);
     }
 
   private:
@@ -164,7 +178,16 @@ class ButtonList final : public juce::ComboBox, public HasScaleFactor, public Ha
             if (auto *obxf = dynamic_cast<ObxfAudioProcessor *>(owner))
             {
                 obxf->setLastUsedParameter(parameter->paramID);
+                obxf::PopupMenuScale::set(obxf->lastImpliedScaleFactor);
             }
+            else
+            {
+                obxf::PopupMenuScale::set(1.f);
+            }
+        }
+        else
+        {
+            obxf::PopupMenuScale::set(1.f);
         }
 
         ComboBox::mouseDown(event);

--- a/src/gui/Knob.h
+++ b/src/gui/Knob.h
@@ -28,6 +28,7 @@
 #include "../src/engine/SynthEngine.h"
 #include "../components/ScalingImageCache.h"
 #include "HasScaleFactor.h"
+#include "PopupMenuScale.h"
 
 #include "sst/plugininfra/misc_platform.h"
 
@@ -48,6 +49,15 @@ class KnobLookAndFeel final : public juce::LookAndFeel_V4
     int getSliderPopupPlacement(juce::Slider &) override
     {
         return juce::BubbleComponent::BubblePlacement::above;
+    }
+
+    juce::Font getSliderPopupFont(juce::Slider &slider) override
+    {
+        auto f = juce::LookAndFeel_V4::getSliderPopupFont(slider);
+        const float scale = obxf::PopupMenuScale::get();
+        if (scale != 1.f)
+            return f.withHeight(f.getHeight() * scale);
+        return f;
     }
 
   private:
@@ -84,17 +94,27 @@ class Knob final : public juce::Slider,
 
         void getIdealSize(int &width, int &height) override
         {
-            width = 120;
-            height = 28;
+            const float scale = obxf::PopupMenuScale::get();
+            width = juce::jmax(1, juce::roundToInt(120.f * scale));
+            height = juce::jmax(1, juce::roundToInt(28.f * scale));
         }
 
-        void resized() override { textEditor->setBounds(getLocalBounds().reduced(3, 1)); }
+        void resized() override
+        {
+            const int pad = juce::jmax(1, juce::roundToInt(3.f * obxf::PopupMenuScale::get()));
+            textEditor->setBounds(getLocalBounds().reduced(pad, pad / 2));
+        }
 
         void visibilityChanged() override
         {
             juce::Timer::callAfterDelay(2, [this]() {
                 if (textEditor->isVisible() && knob)
                 {
+                    const float scale = obxf::PopupMenuScale::get();
+                    textEditor->setFont(juce::FontOptions(14.f * scale));
+                    textEditor->setBorder(
+                        juce::BorderSize<int>(juce::jmax(1, juce::roundToInt(3.f * scale))));
+
                     auto txt = juce::String(knob->getValue());
                     auto md = knob->getMetadata();
 
@@ -120,7 +140,6 @@ class Knob final : public juce::Slider,
                                           juce::Colours::black.withAlpha(0.f));
                     textEditor->setColour(juce::TextEditor::ColourIds::focusedOutlineColourId,
                                           juce::Colours::black.withAlpha(0.f));
-                    textEditor->setBorder(juce::BorderSize<int>(3));
                     textEditor->applyColourToAllText(valCol, true);
                     textEditor->grabKeyboardFocus();
                     textEditor->selectAll();
@@ -329,7 +348,16 @@ class Knob final : public juce::Slider,
             }
         }
 
-        menu.showMenuAsync(juce::PopupMenu::Options().withParentComponent(getTopLevelComponent()));
+        float scale = 1.f;
+        if (auto *obxf = dynamic_cast<ObxfAudioProcessor *>(owner))
+            scale = obxf->lastImpliedScaleFactor;
+        obxf::PopupMenuScale::set(scale);
+        const int itemHeight = juce::jmax(1, juce::roundToInt(22.f * scale));
+        menu.showMenuAsync(
+            juce::PopupMenu::Options()
+                .withTargetComponent(this)
+                .withParentComponent(getTopLevelComponent())
+                .withStandardItemHeight(itemHeight));
     }
 
     void mouseDown(const juce::MouseEvent &event) override

--- a/src/gui/LookAndFeel.h
+++ b/src/gui/LookAndFeel.h
@@ -25,6 +25,7 @@
 
 #include "juce_gui_basics/juce_gui_basics.h"
 #include "BinaryData.h"
+#include "PopupMenuScale.h"
 
 namespace obxf
 {
@@ -176,6 +177,15 @@ class LookAndFeel final : public juce::LookAndFeel_V4
         }
 
         return nullptr;
+    }
+
+    juce::Font getPopupMenuFont() override
+    {
+        auto f = juce::LookAndFeel_V4::getPopupMenuFont();
+        const float scale = PopupMenuScale::get();
+        if (scale != 1.f)
+            return f.withHeight(f.getHeight() * scale);
+        return f;
     }
 
     void drawPopupMenuBackgroundWithOptions(juce::Graphics &g, int width, int height,

--- a/src/gui/PopupMenuScale.h
+++ b/src/gui/PopupMenuScale.h
@@ -1,0 +1,47 @@
+/*
+ * OB-Xf - a continuation of the last open source version of OB-Xd.
+ *
+ * OB-Xd was originally written by Vadim Filatov, and then a version
+ * was released under the GPL3 at https://github.com/reales/OB-Xd.
+ * Subsequently, the product was continued by DiscoDSP and the copyright
+ * holders as an excellent closed source product. For more info,
+ * see "HISTORY.md" in the root of this repository.
+ *
+ * This repository is a successor to the last open source release,
+ * a version marked as 2.11. Copyright 2013-2025 by the authors
+ * as indicated in the original release, and subsequent authors
+ * per the GitHub transaction log.
+ *
+ * OB-Xf is released under the GNU General Public Licence v3 or later
+ * (GPL-3.0-or-later). The license is found in the file "LICENSE"
+ * in the root of this repository or at:
+ * https://www.gnu.org/licenses/gpl-3.0.en.html
+ *
+ * Source code is available at https://github.com/surge-synthesizer/OB-Xf
+ */
+
+#ifndef OBXF_SRC_GUI_POPUPMENUSCALE_H
+#define OBXF_SRC_GUI_POPUPMENUSCALE_H
+
+namespace obxf
+{
+
+/** Thread-local scale factor for popup menus. Set before showMenuAsync so
+ *  LookAndFeel can scale popup font/size to match the plugin UI zoom. */
+namespace PopupMenuScale
+{
+inline thread_local float scaleFactor{1.f};
+
+inline float get()
+{
+    return scaleFactor;
+}
+inline void set(float s)
+{
+    scaleFactor = (s > 0.f) ? s : 1.f;
+}
+}
+
+} // namespace obxf
+
+#endif // OBXF_SRC_GUI_POPUPMENUSCALE_H

--- a/src/gui/ToggleButton.h
+++ b/src/gui/ToggleButton.h
@@ -28,6 +28,7 @@
 #include "../src/engine/SynthEngine.h"
 #include "../components/ScalingImageCache.h"
 #include "HasScaleFactor.h"
+#include "PopupMenuScale.h"
 
 class ToggleButton final : public juce::ImageButton,
                            public HasScaleFactor,
@@ -187,7 +188,16 @@ class ToggleButton final : public juce::ImageButton,
             }
         }
 
-        menu.showMenuAsync(juce::PopupMenu::Options().withParentComponent(getTopLevelComponent()));
+        float scale = 1.f;
+        if (auto *obxf = dynamic_cast<ObxfAudioProcessor *>(owner))
+            scale = obxf->lastImpliedScaleFactor;
+        obxf::PopupMenuScale::set(scale);
+        const int itemHeight = juce::jmax(1, juce::roundToInt(22.f * scale));
+        menu.showMenuAsync(
+            juce::PopupMenu::Options()
+                .withTargetComponent(getTopLevelComponent())
+                .withParentComponent(getTopLevelComponent())
+                .withStandardItemHeight(itemHeight));
     }
 
   private:


### PR DESCRIPTION
This is mostly vibe-coded fix for UI menu scaling issues. Plenty of iteration and testing to get it working perfectly. 

Fixes scaling for:

- All context menus such as browse, poly, voices etc.
- Knob context menus.
- Knob tooltip that shows the current value.

Tested on Mint Cinnamon at 4K with:

- Experimental fractional scaling enabled
- Scaling at 100%
- Scaling at 200%