### PR TITLE
Sustain Pedal fixes

### DIFF
--- a/src/engine/Motherboard.h
+++ b/src/engine/Motherboard.h
@@ -213,12 +213,12 @@ class Motherboard
 
                 if (p->isSounding())
                 {
-                    OBLOG(voiceManager, "  idx=" << p->voiceIndex <<" active " << p->midiNote << " prio=" << voiceAgeForPriority[p->midiNote]
-                                    << " snd=" << p->isSounding()
-                                    << " gt=" <<p->isGated()
-                                    << " sus=" << p->isGatedWithSustain()
-                                    << " on/off " << debugNoteOn[p->midiNote] << "/"
-                                    << debugNoteOff[p->midiNote] );
+                    OBLOG(voiceManager,
+                          "  idx=" << p->voiceIndex << " active " << p->midiNote
+                                   << " prio=" << voiceAgeForPriority[p->midiNote]
+                                   << " snd=" << p->isSounding() << " gt=" << p->isGated()
+                                   << " sus=" << p->isGatedWithSustain() << " on/off "
+                                   << debugNoteOn[p->midiNote] << "/" << debugNoteOff[p->midiNote]);
                 }
             }
 
@@ -438,7 +438,8 @@ class Motherboard
         auto vAvail = voicesAvailable();
         bool should = shouldGivenKeySteal(note);
 
-        OBLOG(voiceManager, "NoteOn: " << note << " vAvail=" << vAvail << " voicesNeeded=" << voicesNeeded << " shouldSteal=" << should);
+        OBLOG(voiceManager, "NoteOn: " << note << " vAvail=" << vAvail << " voicesNeeded="
+                                       << voicesNeeded << " shouldSteal=" << should);
 
         /*
          * First thing - am I actively playing on this key

--- a/src/engine/Voice.h
+++ b/src/engine/Voice.h
@@ -46,10 +46,10 @@ class Voice
     float ampEnvLevel{0.f};
     bool sounding{false};
 
-public:
+  public:
     int voiceIndex{-1};
 
-private:
+  private:
     Tuning *tuning;
 
     struct InternalState
@@ -336,7 +336,7 @@ private:
     bool isSounding() { return sounding; }
     bool isGated() { return gated; }
     bool isGatedWithSustain() { return gatedWithSustain; }
-    bool isGatedOrSustainPedaled() { return gated || gatedWithSustain;}
+    bool isGatedOrSustainPedaled() { return gated || gatedWithSustain; }
 
     void ResetEnvelope()
     {
@@ -349,7 +349,8 @@ private:
     void NoteOn(int note, float vel)
     {
         OBLOG(voiceManager, "idx=" << voiceIndex << ": Note On " << note << " sound=" << sounding
-            << " sustainHold=" << sustainHold << " gated=" << gated << " gatedWithSustain=" << gatedWithSustain)
+                                   << " sustainHold=" << sustainHold << " gated=" << gated
+                                   << " gatedWithSustain=" << gatedWithSustain)
         if (!sounding)
         {
             // When your processing is paused we need to clear delay lines and envelopes
@@ -388,8 +389,10 @@ private:
 
     void NoteOff()
     {
-        OBLOG(voiceManager, "idx=" << voiceIndex << ": Note Off " << midiNote << " sound=" << sounding
-            << " sustainHold=" << sustainHold << " gated=" << gated << " gatedWithSustain=" << gatedWithSustain)
+        OBLOG(voiceManager, "idx=" << voiceIndex << ": Note Off " << midiNote
+                                   << " sound=" << sounding << " sustainHold=" << sustainHold
+                                   << " gated=" << gated
+                                   << " gatedWithSustain=" << gatedWithSustain)
 
         if (!sustainHold)
         {


### PR DESCRIPTION
The sustain pedal was just not working, mostly because the voice manager didn't use isSounding vs isGted vs isGatedWithSustain states properly. So apply a bunch of fixes which make it better even in some tricky voice stealing cases