### PR TITLE
Option to bypass LNF and Host Scale at construct time

### DIFF
--- a/.github/workflows/build-plugin.yml
+++ b/.github/workflows/build-plugin.yml
@@ -197,7 +197,7 @@ jobs:
           webhook: ${{ secrets.DISCORD_OBXF_WEBHOOK }}
           tag: Nightly
           title: "A New OB-Xf Nightly build occurred"
-          subtitle: "The beta period is live. Enjoy!"
+          subtitle: "Headed towards 1.1"
 
       - name: Checkout for git info
         uses: actions/checkout@v6

--- a/src/PluginEditor.cpp
+++ b/src/PluginEditor.cpp
@@ -166,6 +166,13 @@ ObxfAudioProcessorEditor::ObxfAudioProcessorEditor(ObxfAudioProcessor &p)
         }
     }
     resizeOnNextIdle = 3;
+
+    ignoreHostScale = false;
+    dontParentMenusToEditor = false;
+#if JUCE_LINUX
+    if (juce::PluginHostType().isBitwigStudio())
+        dontParentMenusToEditor = true;
+#endif
 }
 
 void ObxfAudioProcessorEditor::parentHierarchyChanged()
@@ -3261,6 +3268,8 @@ void ObxfAudioProcessorEditor::keyboardFocusMainMenu()
 
 void ObxfAudioProcessorEditor::setScaleFactor(float newScale)
 {
+    if (ignoreHostScale)
+        newScale = 1.f;
     utils.setPluginAPIScale(newScale);
     // this line causes the crash with bitmap assets we've been chasing
     // WHy? We kinda need it I think...

--- a/src/PluginEditor.h
+++ b/src/PluginEditor.h
@@ -289,6 +289,9 @@ class ObxfAudioProcessorEditor final : public juce::AudioProcessorEditor,
     void loadPatchFromProgrammer(int whichButton);
     uint8_t currProgrammerGroup{0}, currProgrammerPatch{0};
 
+    bool ignoreHostScale{false};
+    bool dontParentMenusToEditor{false};
+
     bool midiLearnMode = false;
     juce::String midiLearnLastUsedPID;
     std::vector<std::unique_ptr<MidiLearnOverlay>> midiLearnOverlays;

--- a/src/gui/LookAndFeel.cpp
+++ b/src/gui/LookAndFeel.cpp
@@ -27,6 +27,8 @@ namespace obxf
 {
 juce::PopupMenu::Options LookAndFeel::defaultPopupMenuOptions()
 {
+    if (editor && editor->dontParentMenusToEditor)
+        return juce::PopupMenu::Options();
     return juce::PopupMenu::Options().withParentComponent(editor);
 }
 


### PR DESCRIPTION
which we turn on for bitwig linux, which does something funky with menu spacing in 4K in 1.0