### PR TITLE
Revert "Don't retrigger envelopes in legato mode if sustain pedal is pressed (#454)"

### DIFF
--- a/src/engine/Voice.h
+++ b/src/engine/Voice.h
@@ -370,12 +370,12 @@ class Voice
 
         midiNote = note;
 
-        if (!gatedWithSustain || (par.extmod.envLegatoMode & 1))
+        if (!gated || (par.extmod.envLegatoMode & 1))
         {
             ampEnv.triggerAttack();
         }
 
-        if (!gatedWithSustain || (par.extmod.envLegatoMode & 2))
+        if (!gated || (par.extmod.envLegatoMode & 2))
         {
             filterEnv.triggerAttack();
         }
@@ -384,7 +384,7 @@ class Voice
         lfo2.setPhaseDirectly(0.f);
 
         gated = true;
-        gatedWithSustain = false; // only when released am i sustain gated
+        gatedWithSustain = false; // only when released am I sustain gated
     }
 
     void NoteOff()


### PR DESCRIPTION
This reverts commit 3fbb3d17bcadeeb20d2102485b9ff07897cc9909.

Mea maxima culpa, this behavior was simply wrong, and prevents envelope legato from working properly in the first place.