### PR TITLE
Add rudimentary MPE support with per-voice modulation matrix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,5 +111,5 @@ installer-tmp/
 
 BUILD_VERSION
 
+.junie/
 CLAUDE.md
-.junie

--- a/src/PluginEditor.cpp
+++ b/src/PluginEditor.cpp
@@ -27,6 +27,7 @@
 #include "components/ScalingImageCache.h"
 
 #include "gui/AboutScreen.h"
+#include "gui/MPEMatrix.h"
 #include "gui/SaveDialog.h"
 #include "gui/FocusDebugger.h"
 #include "gui/FocusOrder.h"
@@ -88,6 +89,9 @@ ObxfAudioProcessorEditor::ObxfAudioProcessorEditor(ObxfAudioProcessor &p)
 
     saveDialog = std::make_unique<SaveDialog>(*this);
     addChildComponent(*saveDialog);
+
+    mpeMatrixEditor = std::make_unique<MPEMatrixEditor>(processor);
+    addChildComponent(*mpeMatrixEditor);
 
     const auto jersey = juce::Typeface::createSystemTypefaceFor(BinaryData::Jersey20_ttf,
                                                                 BinaryData::Jersey20_ttfSize);
@@ -330,6 +334,13 @@ void ObxfAudioProcessorEditor::resized()
 
     if (saveDialog)
         saveDialog->setBounds(getBounds());
+
+    if (mpeMatrixEditor)
+    {
+        const int w = MPEMatrixEditor::preferredWidth();
+        const int h = MPEMatrixEditor::preferredHeight();
+        mpeMatrixEditor->setBounds((getWidth() - w) / 2, (getHeight() - h) / 2, w, h);
+    }
 
     if (updateProcessorImpliedScaleFactor)
     {
@@ -2477,6 +2488,10 @@ void ObxfAudioProcessorEditor::clean()
     {
         addChildComponent(*saveDialog);
     }
+    if (mpeMatrixEditor)
+    {
+        addChildComponent(*mpeMatrixEditor);
+    }
 }
 
 void ObxfAudioProcessorEditor::rebuildComponents(ObxfAudioProcessor &ownerFilter)
@@ -2593,6 +2608,60 @@ void ObxfAudioProcessorEditor::createMenu()
     createMidiMapMenu(static_cast<int>(midiStart), midiMenu);
 
     menu->addSubMenu(toOSCase("MIDI Mapping"), midiMenu);
+
+    {
+        juce::PopupMenu mpeMenu;
+        auto &midiHandler = processor.getMidiHandler();
+
+        bool mpeOn = midiHandler.mpeEnabled.load();
+        mpeMenu.addItem(toOSCase("MPE Enabled"), true, mpeOn,
+                        [w = juce::Component::SafePointer(this), mpeOn]() {
+                            if (!w)
+                                return;
+                            w->processor.setMpeEnabled(!mpeOn);
+                        });
+
+        mpeMenu.addSeparator();
+        mpeMenu.addSectionHeader(toOSCase("Pitch Bend Range"));
+
+        int curPBR = midiHandler.mpePitchBendRange.load();
+        for (int pbr : {2, 12, 24, 48, 96})
+        {
+            mpeMenu.addItem(fmt::format("{} semitones", pbr), true, curPBR == pbr,
+                            [w = juce::Component::SafePointer(this), pbr]() {
+                                if (!w)
+                                    return;
+                                w->processor.setMpePitchBendRange(pbr);
+                            });
+        }
+
+        mpeMenu.addSeparator();
+        mpeMenu.addItem(toOSCase("Edit MPE Matrix..."), [w = juce::Component::SafePointer(this)]() {
+            if (!w || !w->mpeMatrixEditor)
+                return;
+            w->mpeMatrixEditor->refresh();
+            w->mpeMatrixEditor->setVisible(true);
+            w->mpeMatrixEditor->toFront(true);
+        });
+
+        juce::PopupMenu mpePresetMenu;
+        auto presets = getMatrixPresets();
+        for (int i = 0; i < (int)presets.size(); ++i)
+        {
+            mpePresetMenu.addItem(presets[i].name, [w = juce::Component::SafePointer(this), i]() {
+                if (!w)
+                    return;
+                auto ps = getMatrixPresets();
+                for (int r = 0; r < numMatrixRows; ++r)
+                    w->processor.pushMatrixRowUpdate(r, ps[i].rows[r]);
+                if (w->mpeMatrixEditor && w->mpeMatrixEditor->isVisible())
+                    w->mpeMatrixEditor->syncUI(ps[i].rows);
+            });
+        }
+        mpeMenu.addSubMenu(toOSCase("PRESET (tmp)"), mpePresetMenu);
+
+        menu->addSubMenu(toOSCase("MPE"), mpeMenu);
+    }
 
     {
         juce::PopupMenu themeMenu;

--- a/src/PluginEditor.h
+++ b/src/PluginEditor.h
@@ -52,6 +52,7 @@
 struct AboutScreen;
 struct SaveDialog;
 struct FocusDebugger;
+class MPEMatrixEditor;
 
 using KnobAttachment = Attachment<Knob, true>;
 using ButtonAttachment = Attachment<ToggleButton, false>;
@@ -259,6 +260,8 @@ class ObxfAudioProcessorEditor final : public juce::AudioProcessorEditor,
 
     std::unique_ptr<SaveDialog> saveDialog;
     friend struct SaveDialog;
+
+    std::unique_ptr<MPEMatrixEditor> mpeMatrixEditor;
 
     bool notLoadTheme{false};
     bool skinLoaded{false};

--- a/src/PluginProcessor.cpp
+++ b/src/PluginProcessor.cpp
@@ -103,6 +103,22 @@ void ObxfAudioProcessor::processBlock(juce::AudioBuffer<float> &buffer,
 
     paramCoordinator->getParameterUpdateHandler().updateParameters();
 
+    {
+        auto &vm = synth.getMotherboard()->voiceMatrix;
+        bool anyUpdate = false;
+        while (matrixFifo.hasElement()) [[unlikely]]
+        {
+            auto update = matrixFifo.pop();
+            if (update.index >= 0 && update.index < numMatrixRows)
+            {
+                vm.rows[update.index] = update.row;
+                anyUpdate = true;
+            }
+        }
+        if (anyUpdate)
+            vm.rebuildCache();
+    }
+
     int samplePos = 0;
     const int numSamples = buffer.getNumSamples();
     float *channelData1 = buffer.getWritePointer(0);
@@ -466,6 +482,23 @@ void ObxfAudioProcessor::updateUIState()
     {
         uiState.voiceStatusValue[i] = synth.getVoiceAmpEnvStatus(i);
     }
+}
+
+void ObxfAudioProcessor::setMpeEnabled(bool enabled)
+{
+    midiHandler.mpeEnabled.store(enabled);
+    synth.getMotherboard()->mpeEnabled = enabled;
+}
+
+void ObxfAudioProcessor::setMpePitchBendRange(int range)
+{
+    midiHandler.mpePitchBendRange.store(range);
+    synth.getMotherboard()->mpePitchBendRange = range;
+}
+
+void ObxfAudioProcessor::pushMatrixRowUpdate(int idx, const MatrixRow &row)
+{
+    matrixFifo.push(idx, row);
 }
 
 //==============================================================================

--- a/src/PluginProcessor.h
+++ b/src/PluginProcessor.h
@@ -203,6 +203,15 @@ class ObxfAudioProcessor final : public juce::AudioProcessor,
 
     MidiHandler &getMidiHandler() { return midiHandler; }
 
+    SynthEngine &getSynth() { return synth; }
+
+    void setMpeEnabled(bool enabled);
+    void setMpePitchBendRange(int range);
+    void pushMatrixRowUpdate(int idx, const MatrixRow &row);
+
+    /* Capacity: enough for real edits onto rows as we drag depth */
+    MatrixUpdateFifo<numMatrixRows * 64> matrixFifo;
+
     std::unique_ptr<Utils> utils;
 
     const Program &getActiveProgram() const { return activeProgram; }

--- a/src/configuration.h
+++ b/src/configuration.h
@@ -16,6 +16,7 @@ constexpr uint8_t NUM_PATCHES_PER_GROUP{16};
 constexpr uint8_t NUM_LFOS{2};
 constexpr uint8_t NUM_XPANDER_MODES{15};
 constexpr uint8_t OVERSAMPLE_FACTOR{2};
+constexpr int numMatrixRows{5};
 
 constexpr int fxbVersionNum = 1;
 
@@ -33,6 +34,7 @@ static constexpr bool params{false};
 static constexpr bool paramSet{false};
 static constexpr bool midiLearn{false};
 static constexpr bool voiceManager{false};
+static constexpr bool mpe{false};
 } // namespace obxf_log
 
 // TODO - grab more fulsome version from ShortCircuit

--- a/src/engine/AdsrEnvelope.h
+++ b/src/engine/AdsrEnvelope.h
@@ -143,6 +143,24 @@ class ADSREnvelope
         }
     }
 
+    /* Apply a matrix-driven attack time without touching orig.a.
+     * Safe to call every sample — does not interfere with setEnvOffsets(). */
+    void applyMatrixAttack(float ms)
+    {
+        par.a = ms * offsetFactor / atkTimeAdjustment;
+        if (state == State::Attack)
+            updateAttackCoeff();
+    }
+
+    /* Apply a matrix-driven release time without touching orig.r. */
+    void applyMatrixRelease(float ms)
+    {
+        par.r = ms * offsetFactor;
+        if (state == State::Release)
+            coef = static_cast<float>((log(0.00001) - log(output + 0.0001)) /
+                                      (sampleRate * par.r * msToSec));
+    }
+
     void triggerAttack()
     {
         state = State::Attack;

--- a/src/engine/Motherboard.h
+++ b/src/engine/Motherboard.h
@@ -29,6 +29,7 @@
 #include "SynthEngine.h"
 #include "Lfo.h"
 #include "Tuning.h"
+#include "VoiceMatrix.h"
 
 static constexpr bool ECO_MODE = true;
 
@@ -70,6 +71,10 @@ class Motherboard
     float pannings[MAX_PANNINGS];
     bool unison{false};
     bool oversample{false};
+    bool mpeEnabled{false};
+    int mpePitchBendRange{48};
+
+    VoiceMatrix voiceMatrix;
 
     std::array<int32_t, 128> debugNoteOn{}, debugNoteOff{};
 
@@ -133,7 +138,7 @@ class Motherboard
 
         for (int i = count; i < MAX_VOICES; i++)
         {
-            voices[i].NoteOff();
+            voices[i].NoteOff(0.f);
             voices[i].ResetEnvelope();
         }
 
@@ -422,7 +427,7 @@ class Motherboard
         return false;
     }
 
-    void setNoteOn(int note, float velocity, int8_t /* channel */)
+    void setNoteOn(int note, float velocity, int8_t channel)
     {
         debugNoteOn[note]++;
         // This played note has the highest as-played priority
@@ -449,7 +454,8 @@ class Motherboard
             Voice *v = voiceQueue.getNext();
             if (v->midiNote == note && v->isGated() && voicesNeeded > 0)
             {
-                v->NoteOn(note, velocity);
+                v->NoteOn(note, velocity, channel);
+                recalculateMatrix(voiceMatrix, v->matrixSourceValues, v->matrixAdjustments);
                 voicesNeeded--;
             }
         }
@@ -466,7 +472,8 @@ class Motherboard
                 auto v = nextVoiceToBeStolen();
 
                 stolenVoicesOnMIDIKey[v->midiNote]++;
-                v->NoteOn(note, velocity);
+                v->NoteOn(note, velocity, channel);
+                recalculateMatrix(voiceMatrix, v->matrixSourceValues, v->matrixAdjustments);
                 voicesNeeded--;
 
                 break;
@@ -489,7 +496,8 @@ class Motherboard
 
                 if (!v->isGated())
                 {
-                    v->NoteOn(note, velocity);
+                    v->NoteOn(note, velocity, channel);
+                    recalculateMatrix(voiceMatrix, v->matrixSourceValues, v->matrixAdjustments);
                     voicesNeeded--;
 
                     if (voicesNeeded == 0)
@@ -503,7 +511,7 @@ class Motherboard
         dumpVoiceStatus("NoteOn");
     }
 
-    void setNoteOff(int note, float /* velocity */, int8_t /* channel */)
+    void setNoteOff(int note, float velocity, int8_t channel)
     {
 
         debugNoteOff[note]++;
@@ -519,9 +527,10 @@ class Motherboard
             {
                 Voice *v = voiceQueue.getNext();
 
-                if (v->midiNote == note)
+                if (v->midiNote == note && (!mpeEnabled || v->channel == channel))
                 {
-                    v->NoteOff();
+                    v->NoteOff(velocity);
+                    recalculateMatrix(voiceMatrix, v->matrixSourceValues, v->matrixAdjustments);
                 }
             }
             stolenVoicesOnMIDIKey[note] = 0;
@@ -538,7 +547,8 @@ class Motherboard
 
                 if (p->midiNote == note && p->isGated())
                 {
-                    p->NoteOn(mk, Voice::reuseVelocitySentinel);
+                    p->NoteOn(mk, Voice::reuseVelocitySentinel, p->channel);
+                    recalculateMatrix(voiceMatrix, p->matrixSourceValues, p->matrixAdjustments);
                     stolenVoicesOnMIDIKey[mk]--;
 
                     break;
@@ -561,11 +571,61 @@ class Motherboard
 
             if (v->midiNote == note)
             {
-                v->NoteOff();
+                v->NoteOff(velocity);
+                recalculateMatrix(voiceMatrix, v->matrixSourceValues, v->matrixAdjustments);
             }
         }
 
         dumpVoiceStatus("Note Off (2)");
+    }
+
+    void processMPEPitch(int8_t channel, float pitchBendValue)
+    {
+        // pitchBendValue is -1..1 representing mpePitchBendRange. Scale to semitones with the range
+        const float scaled = pitchBendValue * mpePitchBendRange;
+        for (int i = 0; i < totalVoiceCount; i++)
+        {
+            // isGated not isSounding since long release can reuse channels
+            if (voices[i].channel == channel && voices[i].isGated())
+            {
+                voices[i].mpeBend = scaled;
+                setMatrixSource(voices[i].matrixSourceValues, MatrixSource::VoiceBend,
+                                pitchBendValue);
+                recalculateMatrix(voiceMatrix, voices[i].matrixSourceValues,
+                                  voices[i].matrixAdjustments);
+            }
+        }
+    }
+
+    void processMPETimbre(int8_t channel, float timbreValue)
+    {
+        // timbreValue is 0..1 (CC74 / 127), normalised to -1..1 for the matrix
+        const float normalised = timbreValue * 2.f - 1.f;
+        for (int i = 0; i < totalVoiceCount; i++)
+        {
+            if (voices[i].channel == channel && voices[i].isGated())
+            {
+                setMatrixSource(voices[i].matrixSourceValues, MatrixSource::Timbre, normalised);
+                recalculateMatrix(voiceMatrix, voices[i].matrixSourceValues,
+                                  voices[i].matrixAdjustments);
+            }
+        }
+    }
+
+    void processMPEChannelPressure(int8_t channel, float pressureValue)
+    {
+        // pressureValue is 0..1 (aftertouch / 127), normalised to -1..1 for the matrix
+        const float normalised = pressureValue * 2.f - 1.f;
+        for (int i = 0; i < totalVoiceCount; i++)
+        {
+            if (voices[i].channel == channel && voices[i].isGated())
+            {
+                setMatrixSource(voices[i].matrixSourceValues, MatrixSource::ChannelPressure,
+                                normalised);
+                recalculateMatrix(voiceMatrix, voices[i].matrixSourceValues,
+                                  voices[i].matrixAdjustments);
+            }
+        }
     }
 
     void SetHQMode(bool over, bool force = false)
@@ -604,7 +664,7 @@ class Motherboard
             b.lfo1In = lfo1In;
             b.vibratoLFOIn = vibIn;
 
-            return b.ProcessSample();
+            return b.ProcessSample(voiceMatrix);
         }
 
         return 0.f;

--- a/src/engine/SynthEngine.h
+++ b/src/engine/SynthEngine.h
@@ -112,7 +112,9 @@ class SynthEngine
             if (v.isSounding())
             {
                 v.par.filter.cutoff = co;
-                v.filter.setResonance(re);
+                v.filter.setResonance(juce::jlimit(0.f, 0.991f,
+                                                   re + v.matrixAdjustments.filterResonance *
+                                                            VoiceMatrixRanges::filterResonance));
                 v.filter.setMultimode(fm);
                 v.pitchBend = pb;
             }
@@ -156,6 +158,13 @@ class SynthEngine
     }
 
     void processPitchWheel(float val) { pitchBendSmoother.setStep(val); }
+
+    void processMPEPitch(int8_t channel, float val) { synth.processMPEPitch(channel, val); }
+    void processMPETimbre(int8_t channel, float val) { synth.processMPETimbre(channel, val); }
+    void processMPEChannelPressure(int8_t channel, float val)
+    {
+        synth.processMPEChannelPressure(channel, val);
+    }
 
     void processModWheel(float val) { modWheelSmoother.setStep(val); }
 
@@ -311,6 +320,7 @@ class SynthEngine
         const auto v = logsc(val, 0.f, 250.f, 3775.f);
         ForEachVoice(lfo2.setRate(v));
         ForEachVoice(lfo2.setRateNormalized(val));
+        ForEachVoice(lfo2BaseRate = v);
     }
     void processLFO2Sync(float val)
     {
@@ -512,6 +522,7 @@ class SynthEngine
     {
         const auto v = logsc(val, 4.f, 60000.f, 900.f);
         ForEachVoice(ampEnv.setAttack(v));
+        ForEachVoice(ampEnvAttackBase = v);
     }
     void processAmpEnvDecay(float val)
     {
@@ -523,12 +534,14 @@ class SynthEngine
     {
         const auto v = logsc(val, 8.f, 60000.f, 900.f);
         ForEachVoice(ampEnv.setRelease(v));
+        ForEachVoice(ampEnvReleaseBase = v);
     }
     void processFilterEnvAttackCurve(float val) { ForEachVoice(filterEnv.setAttackCurve(val)); }
     void processFilterEnvAttack(float val)
     {
         const auto v = logsc(val, 1.f, 60000.f, 900.f);
         ForEachVoice(filterEnv.setAttack(v));
+        ForEachVoice(filterEnvAttackBase = v);
     }
     void processFilterEnvDecay(float val)
     {
@@ -540,6 +553,7 @@ class SynthEngine
     {
         const auto v = logsc(val, 1.f, 60000.f, 900.f);
         ForEachVoice(filterEnv.setRelease(v));
+        ForEachVoice(filterEnvReleaseBase = v);
     }
     void processEnvelopeSlop(float val) { ForEachVoice(setEnvTimingOffset(val)); }
     void processFilterSlop(float val)

--- a/src/engine/Voice.h
+++ b/src/engine/Voice.h
@@ -29,6 +29,7 @@
 #include "Filter.h"
 #include "Decimator.h"
 #include "Tuning.h"
+#include "VoiceMatrix.h"
 
 class Voice
 {
@@ -146,11 +147,23 @@ class Voice
     } par;
 
     int midiNote{60};
+    int16_t channel{0};
+    VoiceMatrixAdjustments matrixAdjustments{};
+    VoiceMatrixSourceValues matrixSourceValues{};
     float pitchBend{0.f};
+    float mpeBend{0.f};
     bool sustainHold{false};
 
     float lfo1In{0.f};
     float vibratoLFOIn{0.f};
+
+    /* Base values (in native units) used by the matrix to compute per-voice adjustments.
+     * Set by SynthEngine process* functions alongside the global voice setter. */
+    float lfo2BaseRate{0.f};
+    float filterEnvAttackBase{1.f}; // ms, matches logsc(0, 1, 60000, 900) default
+    float filterEnvReleaseBase{1.f};
+    float ampEnvAttackBase{4.f}; // ms, matches logsc(0, 4, 60000, 900) default
+    float ampEnvReleaseBase{8.f};
 
     DelayLine<B_SAMPLES * OVERSAMPLE_FACTOR, float> ampEnvDelayed, filterEnvDelayed, lfo1Delayed,
         lfo2Delayed;
@@ -168,11 +181,25 @@ class Voice
 
     void initTuning(Tuning *t) { tuning = t; }
 
-    inline float ProcessSample()
+    inline float ProcessSample(const VoiceMatrix &voiceMatrix)
     {
+        // Apply per-voice LFO2 rate offset before updating
+        lfo2.setRate(juce::jmax(0.01f, lfo2BaseRate + matrixAdjustments.lfo2Rate *
+                                                          VoiceMatrixRanges::lfo2Rate));
         lfo2.update();
 
         float lfo2In = lfo2.getVal();
+        /* Recalculate every sample only when LFO2 is wired into the matrix —
+         * otherwise recalculation happens at note/MPE events (see Motherboard).
+         * NOTE: when per-sample matrix smoothing is added, recalculation will
+         * be needed every sample regardless, and this guard should be modifiedf
+         * .
+         */
+        if (voiceMatrix.isLFO2Bound)
+        {
+            matrixSourceValues.lfo2 = lfo2In;
+            recalculateMatrix(voiceMatrix, matrixSourceValues, matrixAdjustments);
+        }
 
         double tunedNote = tuning->tunedMidiNote(midiNote);
 
@@ -183,13 +210,38 @@ class Voice
 
         // rescale pitch bend
         float pitchBendScaled =
-            (pitchBend < 0.f) ? (pitchBend * par.extmod.pbDown) : (pitchBend * par.extmod.pbUp);
+            ((pitchBend < 0.f) ? (pitchBend * par.extmod.pbDown) : (pitchBend * par.extmod.pbUp)) +
+            mpeBend;
 
         oscs.par.pitch.notePlaying = portaProcessed;
 
         // envelope and LFO applied to the filter need a delay equal to internal oscillator delay
         float filterLFO1Mod = lfo1Delayed.feedReturn(lfo1In);
         float filterLFO2Mod = lfo2Delayed.feedReturn(lfo2In);
+
+        // apply per-voice LFO mod-amount adjustments (save/restore to avoid accumulation)
+        const float savedLfo1Amt1 = par.lfo1.amt1;
+        const float savedLfo1Amt2 = par.lfo1.amt2;
+        const float savedLfo2Amt1 = par.lfo2.amt1;
+        const float savedLfo2Amt2 = par.lfo2.amt2;
+        par.lfo1.amt1 = juce::jmax(0.f, par.lfo1.amt1 + matrixAdjustments.lfo1Mod1 *
+                                                            VoiceMatrixRanges::lfo1Mod1);
+        par.lfo1.amt2 = juce::jlimit(
+            0.f, 0.7f, par.lfo1.amt2 + matrixAdjustments.lfo1Mod2 * VoiceMatrixRanges::lfo1Mod2);
+        par.lfo2.amt1 = juce::jmax(0.f, par.lfo2.amt1 + matrixAdjustments.lfo2Mod1 *
+                                                            VoiceMatrixRanges::lfo2Mod1);
+        par.lfo2.amt2 = juce::jlimit(
+            0.f, 0.7f, par.lfo2.amt2 + matrixAdjustments.lfo2Mod2 * VoiceMatrixRanges::lfo2Mod2);
+
+        // apply per-voice filter envelope timing adjustments before processSample
+        if (matrixAdjustments.filterEnvAttack != 0.f)
+            filterEnv.applyMatrixAttack(
+                juce::jmax(1.f, filterEnvAttackBase + matrixAdjustments.filterEnvAttack *
+                                                          VoiceMatrixRanges::filterEnvAttack));
+        if (matrixAdjustments.filterEnvRelease != 0.f)
+            filterEnv.applyMatrixRelease(
+                juce::jmax(1.f, filterEnvReleaseBase + matrixAdjustments.filterEnvRelease *
+                                                           VoiceMatrixRanges::filterEnvRelease));
 
         // filter envelope
         float modEnv = par.filter.invertEnvScale * filterEnv.processSample() *
@@ -206,7 +258,8 @@ class Voice
                      (par.lfo2.cutoff * filterLFO2Mod * par.lfo2.amt1) + par.filter.cutoff +
                      slop.cutoff * par.slop.cutoff +
                      par.filter.envAmt * filterEnvDelayed.feedReturn(modEnv) - 45 +
-                     (par.filter.keytrack * (pitchBendScaled + oscs.par.pitch.notePlaying + 40)));
+                     (par.filter.keytrack * (pitchBendScaled + oscs.par.pitch.notePlaying + 40)) +
+                     matrixAdjustments.filterCutoff * VoiceMatrixRanges::filterCutoff);
 
         // limit max cutoff for numerical stability
         float cutoffcalc = std::min(cutoffPitch + noisyCutoff, (sampleRate * 0.5f - 120.0f));
@@ -225,7 +278,8 @@ class Voice
                                  (par.osc.envPWBothOscs ? (par.osc.envPWAmt * pwenv) : 0);
         oscs.par.mod.osc2PWMod = (par.lfo1.osc2PW * lfo1In * par.lfo1.amt2) +
                                  (par.lfo2.osc2PW * lfo2In * par.lfo2.amt2) +
-                                 (par.osc.envPWAmt * pwenv) + par.osc.pwOsc2Offset;
+                                 (par.osc.envPWAmt * pwenv) + par.osc.pwOsc2Offset +
+                                 matrixAdjustments.osc2PWOffset * VoiceMatrixRanges::osc2PWOffset;
 
         // pitch modulation
         float pitchEnv = modEnv * (oscs.par.mod.envToPitchInvert ? -1 : 1);
@@ -234,14 +288,64 @@ class Voice
             (!par.extmod.pbOsc2Only ? pitchBendScaled : 0) +
             (par.lfo1.osc1Pitch * lfo1In * par.lfo1.amt1) +
             (par.lfo2.osc1Pitch * lfo2In * par.lfo2.amt1) +
-            (par.osc.envPitchBothOscs ? (par.osc.envPitchAmt * pitchEnv) : 0) + vibratoLFOIn;
-        oscs.par.mod.osc2PitchMod = pitchBendScaled +
-                                    (par.lfo1.osc2Pitch * lfo1In * par.lfo1.amt1) +
-                                    (par.lfo2.osc2Pitch * lfo2In * par.lfo2.amt1) +
-                                    (par.osc.envPitchAmt * pitchEnv) + vibratoLFOIn;
+            (par.osc.envPitchBothOscs ? (par.osc.envPitchAmt * pitchEnv) : 0) + vibratoLFOIn +
+            matrixAdjustments.osc1Pitch * VoiceMatrixRanges::osc1Pitch +
+            matrixAdjustments.oscPitch * VoiceMatrixRanges::oscPitch;
+        oscs.par.mod.osc2PitchMod =
+            pitchBendScaled + (par.lfo1.osc2Pitch * lfo1In * par.lfo1.amt1) +
+            (par.lfo2.osc2Pitch * lfo2In * par.lfo2.amt1) + (par.osc.envPitchAmt * pitchEnv) +
+            vibratoLFOIn + matrixAdjustments.osc2Pitch * VoiceMatrixRanges::osc2Pitch +
+            matrixAdjustments.oscPitch * VoiceMatrixRanges::oscPitch;
+
+        // apply matrix adjustments to oscillator mix, detune, PW, crossmod, unison before
+        // processing; save and restore to avoid per-sample accumulation
+        const float savedOsc1 = oscs.par.mix.osc1;
+        const float savedOsc2 = oscs.par.mix.osc2;
+        const float savedNoise = oscs.par.mix.noise;
+        const float savedRingMod = oscs.par.mix.ringMod;
+        const float savedNoiseColor = oscs.par.mix.noiseColor;
+        const float savedDetune = oscs.par.osc.detune;
+        const float savedUnisonDetune = oscs.par.pitch.unisonDetune;
+        const float savedOscPW = oscs.par.osc.pw;
+        const float savedCrossmod = oscs.par.osc.crossmod;
+
+        oscs.par.mix.osc1 = juce::jmax(0.f, oscs.par.mix.osc1 + matrixAdjustments.osc1Vol *
+                                                                    VoiceMatrixRanges::osc1Vol);
+        oscs.par.mix.osc2 = juce::jmax(0.f, oscs.par.mix.osc2 + matrixAdjustments.osc2Vol *
+                                                                    VoiceMatrixRanges::osc2Vol);
+        oscs.par.mix.noise = juce::jmax(0.f, oscs.par.mix.noise + matrixAdjustments.noiseVol *
+                                                                      VoiceMatrixRanges::noiseVol);
+        oscs.par.mix.ringMod =
+            juce::jmax(0.f, oscs.par.mix.ringMod +
+                                matrixAdjustments.ringModVol * VoiceMatrixRanges::ringModVol);
+        oscs.par.mix.noiseColor = juce::jlimit(
+            0.f, 1.f,
+            oscs.par.mix.noiseColor + matrixAdjustments.noiseColor * VoiceMatrixRanges::noiseColor);
+        oscs.par.osc.detune =
+            oscs.par.osc.detune +
+            matrixAdjustments.osc2Detune *
+                VoiceMatrixRanges::osc2Detune; // NOTE: detune is log-scaled by SynthEngine;
+                                               // adjustment is additive in that space
+        oscs.par.pitch.unisonDetune =
+            juce::jmax(0.001f, oscs.par.pitch.unisonDetune + matrixAdjustments.unisonDetune *
+                                                                 VoiceMatrixRanges::unisonDetune);
+        oscs.par.osc.pw = juce::jlimit(
+            0.f, 0.95f, oscs.par.osc.pw + matrixAdjustments.oscPW * VoiceMatrixRanges::oscPW);
+        oscs.par.osc.crossmod = juce::jmax(
+            0.f, oscs.par.osc.crossmod + matrixAdjustments.crossmod * VoiceMatrixRanges::crossmod);
 
         // process oscillator block
         float oscSample = oscs.ProcessSample() * (1 - par.slop.level * slop.level);
+
+        oscs.par.mix.osc1 = savedOsc1;
+        oscs.par.mix.osc2 = savedOsc2;
+        oscs.par.mix.noise = savedNoise;
+        oscs.par.mix.ringMod = savedRingMod;
+        oscs.par.mix.noiseColor = savedNoiseColor;
+        oscs.par.osc.detune = savedDetune;
+        oscs.par.pitch.unisonDetune = savedUnisonDetune;
+        oscs.par.osc.pw = savedOscPW;
+        oscs.par.osc.crossmod = savedCrossmod;
 
         // process oscillator brightness
         oscSample = oscSample - tpt_lp_unwarped(state.oscBlock, oscSample, 12, sampleRateInv);
@@ -262,6 +366,22 @@ class Voice
 
         oscSample *= 1.f - (par.lfo2.volume * lfo2In * 0.5f + par.lfo2.absVolume * 0.5f) *
                                (par.lfo2.amt2 * 1.4285714285714286f);
+
+        // restore LFO mod amounts
+        par.lfo1.amt1 = savedLfo1Amt1;
+        par.lfo1.amt2 = savedLfo1Amt2;
+        par.lfo2.amt1 = savedLfo2Amt1;
+        par.lfo2.amt2 = savedLfo2Amt2;
+
+        // apply per-voice amp envelope timing adjustments before processSample
+        if (matrixAdjustments.ampEnvAttack != 0.f)
+            ampEnv.applyMatrixAttack(
+                juce::jmax(1.f, ampEnvAttackBase + matrixAdjustments.ampEnvAttack *
+                                                       VoiceMatrixRanges::ampEnvAttack));
+        if (matrixAdjustments.ampEnvRelease != 0.f)
+            ampEnv.applyMatrixRelease(
+                juce::jmax(1.f, ampEnvReleaseBase + matrixAdjustments.ampEnvRelease *
+                                                        VoiceMatrixRanges::ampEnvRelease));
 
         // amp envelope
         float ampEnvVal = ampEnvDelayed.feedReturn(ampEnv.processSample() *
@@ -356,7 +476,7 @@ class Voice
 
     static constexpr float reuseVelocitySentinel{-0.5f};
 
-    void NoteOn(int note, float vel)
+    void NoteOn(int note, float vel, int16_t chan)
     {
         OBLOG(voiceManager, "idx=" << voiceIndex << ": Note On " << note << " sound=" << sounding
                                    << " sustainHold=" << sustainHold << " gated=" << gated
@@ -379,6 +499,15 @@ class Voice
         }
 
         midiNote = note;
+        channel = chan;
+        mpeBend = 0.f;
+        matrixAdjustments.clear();
+        matrixSourceValues.clear();
+        /* Velocity is known at note-on time; set it now so Motherboard can
+         * recalculateMatrix immediately after this call with a consistent state.
+         * Works correctly for the reuseVelocitySentinel path too, since
+         * velocity holds its preserved value by this point. */
+        setMatrixSource(matrixSourceValues, MatrixSource::Velocity, velocity);
 
         if (!gated || (par.extmod.envLegatoMode & 1))
         {
@@ -397,12 +526,16 @@ class Voice
         gatedWithSustain = false; // only when released am I sustain gated
     }
 
-    void NoteOff()
+    void NoteOff(float releaseVelocity)
     {
         OBLOG(voiceManager, "idx=" << voiceIndex << ": Note Off " << midiNote
                                    << " sound=" << sounding << " sustainHold=" << sustainHold
                                    << " gated=" << gated
                                    << " gatedWithSustain=" << gatedWithSustain)
+
+        /* Set release velocity source; leave other sources (bend, pressure, timbre) intact
+         * so they remain active through the release phase. */
+        setMatrixSource(matrixSourceValues, MatrixSource::ReleaseVelocity, releaseVelocity);
 
         if (!sustainHold)
         {

--- a/src/engine/VoiceMatrix.h
+++ b/src/engine/VoiceMatrix.h
@@ -1,0 +1,633 @@
+/*
+ * OB-Xf - a continuation of the last open source version of OB-Xd.
+ *
+ * OB-Xd was originally written by Vadim Filatov, and then a version
+ * was released under the GPL3 at https://github.com/reales/OB-Xd.
+ * Subsequently, the product was continued by DiscoDSP and the copyright
+ * holders as an excellent closed source product. For more info,
+ * see "HISTORY.md" in the root of this repository.
+ *
+ * This repository is a successor to the last open source release,
+ * a version marked as 2.11. Copyright 2013-2025 by the authors
+ * as indicated in the original release, and subsequent authors
+ * per the GitHub transaction log.
+ *
+ * OB-Xf is released under the GNU General Public Licence v3 or later
+ * (GPL-3.0-or-later). The license is found in the file "LICENSE"
+ * in the root of this repository or at:
+ * https://www.gnu.org/licenses/gpl-3.0.en.html
+ *
+ * Source code is available at https://github.com/surge-synthesizer/OB-Xf
+ */
+
+#ifndef OBXF_SRC_ENGINE_VOICEMATRIX_H
+#define OBXF_SRC_ENGINE_VOICEMATRIX_H
+
+#include <array>
+#include <string>
+#include <unordered_set>
+
+#include <juce_core/juce_core.h>
+
+#include "configuration.h"
+#include "SynthParam.h"
+
+/*
+ * VoiceMatrix: per-synth modulation routing from MPE/voice sources to per-voice targets.
+ * Sources are enumerated below; targets are SynthParam ID strings.
+ * The matrix has numMatrixRows rows, each with a source, target, and depth.
+ */
+
+/*
+ * HOW TO ADD A NEW MODULATION SOURCE
+ * ------------------------------------
+ * 1. MatrixSource enum      — add your entry (e.g. Aftertouch).
+ * 2. matrixSourceToString() — add a case returning a stable string literal.
+ * 3. matrixSourceFromString() — add the matching reverse case.
+ * 4. VoiceMatrixSourceValues — add a float field (e.g. aftertouch{0.f}).
+ * 5. VoiceMatrixSourceValues::get() — add a case returning the new field.
+ * 6. VoiceMatrixSourceValues::set() — add a case writing the new field.
+ * 7. Wire it up — call setMatrixSource() + recalculateMatrix() from wherever
+ *    the source value arrives:
+ *      - Per-voice at note start: Voice::NoteOn() sets the field after
+ *        matrixSourceValues.clear(); Motherboard calls recalculateMatrix().
+ *      - Per-voice at note end: Voice::NoteOff() sets the field;
+ *        Motherboard calls recalculateMatrix().
+ *      - Per-channel real-time: Motherboard::processMPE*() follows the
+ *        same pattern as processMPETimbre / processMPEChannelPressure.
+ * 8. MPEMatrixEditor (src/gui/MPEMatrix.h) — add the item to the source
+ *    combo box and update sourceToId() / idToSource().
+ *
+ * HOW TO ADD A NEW MODULATION TARGET
+ * ------------------------------------
+ * 1. VoiceMatrixAdjustments — add a float field (e.g. osc1PWOffset{0.f})
+ *    and clear it in clear().
+ * 2. VoiceMatrixRanges      — add a static constexpr float for the natural
+ *    scale: +/-1 source maps to +/- that many native units.
+ * 3. isValidMatrixTarget()  — add the SynthParam::ID string to the set.
+ * 4. recalculateMatrix()    — add an else-if branch that accumulates
+ *    contribution into the new field.
+ * 5. Voice::ProcessSample() — consume the adjustment at the right point
+ *    in the signal path, e.g.:
+ *      foo = bar + matrixAdjustments.osc1PWOffset * VoiceMatrixRanges::osc1PWOffset;
+ * 6. MPEMatrixEditor (src/gui/MPEMatrix.h) — add the item to the target
+ *    combo box and update targetToId() / idToTarget().
+ */
+
+// ---------------------------------------------------------------------------
+// Source enum — use string conversion for stable streaming (not int values)
+// ---------------------------------------------------------------------------
+enum class MatrixSource
+{
+    VoiceBend,
+    ChannelPressure,
+    Timbre,
+    Velocity,
+    ReleaseVelocity,
+    LFO2,
+    None
+};
+
+inline std::string matrixSourceToString(MatrixSource src)
+{
+    switch (src)
+    {
+    case MatrixSource::VoiceBend:
+        return "VoiceBend";
+    case MatrixSource::ChannelPressure:
+        return "ChannelPressure";
+    case MatrixSource::Timbre:
+        return "Timbre";
+    case MatrixSource::Velocity:
+        return "Velocity";
+    case MatrixSource::ReleaseVelocity:
+        return "ReleaseVelocity";
+    case MatrixSource::LFO2:
+        return "LFO2";
+    case MatrixSource::None:
+    default:
+        return "None";
+    }
+}
+
+inline MatrixSource matrixSourceFromString(const std::string &s)
+{
+    if (s == "VoiceBend")
+        return MatrixSource::VoiceBend;
+    if (s == "ChannelPressure")
+        return MatrixSource::ChannelPressure;
+    if (s == "Timbre")
+        return MatrixSource::Timbre;
+    if (s == "Velocity")
+        return MatrixSource::Velocity;
+    if (s == "ReleaseVelocity")
+        return MatrixSource::ReleaseVelocity;
+    if (s == "LFO2")
+        return MatrixSource::LFO2;
+    return MatrixSource::None;
+}
+
+/*
+ * VoiceMatrixAdjustments: per-voice modulation accumulator.
+ * Contains one float per valid matrix target — keep this in sync with
+ * isValidMatrixTarget() below.
+ */
+struct VoiceMatrixAdjustments
+{
+    // Keep in sync with isValidMatrixTarget()
+    float filterCutoff{0.f};
+    float filterResonance{0.f};
+    float osc1Pitch{0.f};
+    float osc2Pitch{0.f};
+    float osc2Detune{0.f};
+    float osc2PWOffset{0.f};
+    float osc1Vol{0.f};
+    float osc2Vol{0.f};
+    float noiseVol{0.f};
+    float ringModVol{0.f};
+    float noiseColor{0.f};
+    float oscPitch{0.f}; // both Osc1 and Osc2 pitch together
+    float unisonDetune{0.f};
+    float oscPW{0.f}; // shared pulse width
+    float crossmod{0.f};
+    float lfo1Mod1{0.f};
+    float lfo1Mod2{0.f};
+    float lfo2Rate{0.f};
+    float lfo2Mod1{0.f};
+    float lfo2Mod2{0.f};
+    float filterEnvAttack{0.f};
+    float filterEnvRelease{0.f};
+    float ampEnvAttack{0.f};
+    float ampEnvRelease{0.f};
+
+    void clear()
+    {
+        filterCutoff = 0.f;
+        filterResonance = 0.f;
+        osc1Pitch = 0.f;
+        osc2Pitch = 0.f;
+        osc2Detune = 0.f;
+        osc2PWOffset = 0.f;
+        osc1Vol = 0.f;
+        osc2Vol = 0.f;
+        noiseVol = 0.f;
+        ringModVol = 0.f;
+        noiseColor = 0.f;
+        oscPitch = 0.f;
+        unisonDetune = 0.f;
+        oscPW = 0.f;
+        crossmod = 0.f;
+        lfo1Mod1 = 0.f;
+        lfo1Mod2 = 0.f;
+        lfo2Rate = 0.f;
+        lfo2Mod1 = 0.f;
+        lfo2Mod2 = 0.f;
+        filterEnvAttack = 0.f;
+        filterEnvRelease = 0.f;
+        ampEnvAttack = 0.f;
+        ampEnvRelease = 0.f;
+    }
+};
+
+/*
+ * VoiceMatrixRanges: natural scale for each modulation target.
+ * +/-1 source value maps to +/- the range value in the target's native units.
+ * Keep in sync with VoiceMatrixAdjustments above and isValidMatrixTarget() below.
+ */
+struct VoiceMatrixRanges
+{
+    // Pitch targets: +/-1 = +/-48 semitones
+    static constexpr float filterCutoff{48.f};
+    static constexpr float osc1Pitch{48.f};
+    static constexpr float osc2Pitch{48.f};
+    // All other targets: +/-1 = +/-1 (full range)
+    static constexpr float filterResonance{1.f};
+    static constexpr float osc2Detune{1.f};
+    static constexpr float osc2PWOffset{1.f};
+    static constexpr float osc1Vol{1.f};
+    static constexpr float osc2Vol{1.f};
+    static constexpr float noiseVol{1.f};
+    static constexpr float ringModVol{1.f};
+    static constexpr float noiseColor{1.f};
+    // Both-osc pitch: same scale as individual pitches
+    static constexpr float oscPitch{48.f};
+    // Unison detune: +/-1 = +/-1 in log-scaled unison-detune space
+    static constexpr float unisonDetune{1.f};
+    // Osc PW: +/-1 = +/-0.95 (full PW range)
+    static constexpr float oscPW{0.95f};
+    // Crossmod: +/-1 = +/-48 (matching processCrossmod scale)
+    static constexpr float crossmod{48.f};
+    // LFO mod amounts: +/-1 = full processed range
+    static constexpr float lfo1Mod1{60.f};  // amt1 max after logsc chain
+    static constexpr float lfo1Mod2{0.7f};  // amt2 max (linsc 0..0.7)
+    static constexpr float lfo2Rate{250.f}; // Hz, full LFO2 rate range
+    static constexpr float lfo2Mod1{60.f};
+    static constexpr float lfo2Mod2{0.7f};
+    // Envelope times: +/-1 = +/-10 seconds (ms)
+    static constexpr float filterEnvAttack{10000.f};
+    static constexpr float filterEnvRelease{10000.f};
+    static constexpr float ampEnvAttack{10000.f};
+    static constexpr float ampEnvRelease{10000.f};
+};
+
+// ---------------------------------------------------------------------------
+// Valid modulation targets — keep in sync with VoiceMatrixAdjustments above
+// ---------------------------------------------------------------------------
+inline bool isValidMatrixTarget(const std::string &tgt)
+{
+    static const std::unordered_set<std::string> validTargets = {
+        SynthParam::ID::FilterCutoff,    SynthParam::ID::FilterResonance,
+        SynthParam::ID::Osc1Pitch,       SynthParam::ID::Osc2Pitch,
+        SynthParam::ID::Osc2Detune,      SynthParam::ID::Osc2PWOffset,
+        SynthParam::ID::Osc1Vol,         SynthParam::ID::Osc2Vol,
+        SynthParam::ID::NoiseVol,        SynthParam::ID::RingModVol,
+        SynthParam::ID::NoiseColor,      SynthParam::ID::OscPitch,
+        SynthParam::ID::UnisonDetune,    SynthParam::ID::OscPW,
+        SynthParam::ID::OscCrossmod,     SynthParam::ID::LFO1ModAmount1,
+        SynthParam::ID::LFO1ModAmount2,  SynthParam::ID::LFO2Rate,
+        SynthParam::ID::LFO2ModAmount1,  SynthParam::ID::LFO2ModAmount2,
+        SynthParam::ID::FilterEnvAttack, SynthParam::ID::FilterEnvRelease,
+        SynthParam::ID::AmpEnvAttack,    SynthParam::ID::AmpEnvRelease,
+    };
+    return validTargets.count(tgt) > 0;
+}
+
+// ---------------------------------------------------------------------------
+// A single matrix row
+// ---------------------------------------------------------------------------
+struct MatrixRow
+{
+    MatrixSource source{MatrixSource::None};
+    std::string target{}; // SynthParam::ID string, empty = unassigned
+    float depth{0.f};     // -1..1
+
+    bool isActive() const { return source != MatrixSource::None && !target.empty(); }
+};
+
+// ---------------------------------------------------------------------------
+// The matrix itself — lives on the synth, streams in the patch XML
+// ---------------------------------------------------------------------------
+struct VoiceMatrix
+{
+    std::array<MatrixRow, numMatrixRows> rows{};
+
+    /* True when at least one active row uses LFO2 as its source.
+     * Cached on every matrix edit so Voice::ProcessSample can skip
+     * recalculateMatrix() on patches that don't use LFO2.
+     * NOTE: when per-sample matrix smoothing is added this optimisation
+     * will need revisiting — smoothing will require recalculation every
+     * sample regardless of source type. */
+    bool isLFO2Bound{false};
+
+    /* Returns false if source/target are invalid or idx is out of range */
+    bool setModulation(const std::string &src, const std::string &tgt, float depth, int idx)
+    {
+        if (idx < 0 || idx >= numMatrixRows)
+            return false;
+
+        auto s = matrixSourceFromString(src);
+        if (s == MatrixSource::None)
+            return false;
+
+        if (!isValidMatrixTarget(tgt))
+            return false;
+
+        rows[idx].source = s;
+        rows[idx].target = tgt;
+        rows[idx].depth = depth;
+        rebuildCache();
+        return true;
+    }
+
+    void clearRow(int idx)
+    {
+        if (idx >= 0 && idx < numMatrixRows)
+        {
+            rows[idx] = MatrixRow{};
+            rebuildCache();
+        }
+    }
+
+    void clear()
+    {
+        rows.fill(MatrixRow{});
+        rebuildCache();
+    }
+
+    // -----------------------------------------------------------------------
+    // XML streaming — call toElement / fromElement from patch save/load
+    // -----------------------------------------------------------------------
+    std::unique_ptr<juce::XmlElement> toElement() const
+    {
+        auto el = std::make_unique<juce::XmlElement>("VoiceMatrix");
+        for (int i = 0; i < numMatrixRows; ++i)
+        {
+            const auto &row = rows[i];
+            if (!row.isActive())
+                continue;
+
+            auto *rowEl = new juce::XmlElement("row");
+            rowEl->setAttribute("idx", i);
+            rowEl->setAttribute("source", matrixSourceToString(row.source));
+            rowEl->setAttribute("target", row.target);
+            rowEl->setAttribute("depth", row.depth);
+            el->addChildElement(rowEl);
+        }
+        return el;
+    }
+
+    void fromElement(const juce::XmlElement *el)
+    {
+        rows.fill(MatrixRow{}); // don't call clear() — rebuildCache() follows below
+        if (!el)
+        {
+            rebuildCache();
+            return;
+        }
+
+        for (auto *rowEl : el->getChildIterator())
+        {
+            int idx = rowEl->getIntAttribute("idx", -1);
+            if (idx < 0 || idx >= numMatrixRows)
+                continue;
+
+            rows[idx].source =
+                matrixSourceFromString(rowEl->getStringAttribute("source").toStdString());
+            rows[idx].target = rowEl->getStringAttribute("target").toStdString();
+            rows[idx].depth = static_cast<float>(rowEl->getDoubleAttribute("depth", 0.0));
+        }
+        rebuildCache();
+    }
+
+    void rebuildCache()
+    {
+        isLFO2Bound = false;
+        for (const auto &row : rows)
+        {
+            if (row.isActive() && row.source == MatrixSource::LFO2)
+            {
+                isLFO2Bound = true;
+                return;
+            }
+        }
+    }
+};
+
+/*
+ * VoiceMatrixSourceValues: stores the last received value for each matrix source,
+ * normalised to -1..1. Lives on each Voice so recalculateMatrix can recompute
+ * adjustments from scratch without accumulation.
+ */
+struct VoiceMatrixSourceValues
+{
+    float voiceBend{0.f};
+    float channelPressure{0.f};
+    float timbre{0.f};
+    float velocity{0.f};
+    float releaseVelocity{0.f};
+    float lfo2{0.f};
+
+    void clear()
+    {
+        voiceBend = 0.f;
+        channelPressure = 0.f;
+        timbre = 0.f;
+        velocity = 0.f;
+        releaseVelocity = 0.f;
+        lfo2 = 0.f;
+    }
+
+    float get(MatrixSource src) const
+    {
+        switch (src)
+        {
+        case MatrixSource::VoiceBend:
+            return voiceBend;
+        case MatrixSource::ChannelPressure:
+            return channelPressure;
+        case MatrixSource::Timbre:
+            return timbre;
+        case MatrixSource::Velocity:
+            return velocity;
+        case MatrixSource::ReleaseVelocity:
+            return releaseVelocity;
+        case MatrixSource::LFO2:
+            return lfo2;
+        default:
+            return 0.f;
+        }
+    }
+
+    void set(MatrixSource src, float value)
+    {
+        switch (src)
+        {
+        case MatrixSource::VoiceBend:
+            voiceBend = value;
+            break;
+        case MatrixSource::ChannelPressure:
+            channelPressure = value;
+            break;
+        case MatrixSource::Timbre:
+            timbre = value;
+            break;
+        case MatrixSource::Velocity:
+            velocity = value;
+            break;
+        case MatrixSource::ReleaseVelocity:
+            releaseVelocity = value;
+            break;
+        case MatrixSource::LFO2:
+            lfo2 = value;
+            break;
+        default:
+            break;
+        }
+    }
+};
+
+// ---------------------------------------------------------------------------
+// setMatrixTarget: store a source value on a voice, then call recalculateMatrix.
+// value should be normalised to -1..1 before calling.
+// ---------------------------------------------------------------------------
+inline void setMatrixSource(VoiceMatrixSourceValues &srcVals, MatrixSource src, float value)
+{
+    srcVals.set(src, value);
+}
+
+// ---------------------------------------------------------------------------
+// recalculateMatrix: zero adjustments and recompute from stored source values.
+// Call after any source value changes to avoid accumulation.
+// ---------------------------------------------------------------------------
+inline void recalculateMatrix(const VoiceMatrix &matrix, const VoiceMatrixSourceValues &srcVals,
+                              VoiceMatrixAdjustments &adj)
+{
+    adj.clear();
+    for (const auto &row : matrix.rows)
+    {
+        if (!row.isActive())
+            continue;
+
+        const float contribution = srcVals.get(row.source) * row.depth;
+
+        if (row.target == SynthParam::ID::FilterCutoff)
+            adj.filterCutoff += contribution;
+        else if (row.target == SynthParam::ID::FilterResonance)
+            adj.filterResonance += contribution;
+        else if (row.target == SynthParam::ID::Osc1Pitch)
+            adj.osc1Pitch += contribution;
+        else if (row.target == SynthParam::ID::Osc2Pitch)
+            adj.osc2Pitch += contribution;
+        else if (row.target == SynthParam::ID::Osc2Detune)
+            adj.osc2Detune += contribution;
+        else if (row.target == SynthParam::ID::Osc2PWOffset)
+            adj.osc2PWOffset += contribution;
+        else if (row.target == SynthParam::ID::Osc1Vol)
+            adj.osc1Vol += contribution;
+        else if (row.target == SynthParam::ID::Osc2Vol)
+            adj.osc2Vol += contribution;
+        else if (row.target == SynthParam::ID::NoiseVol)
+            adj.noiseVol += contribution;
+        else if (row.target == SynthParam::ID::RingModVol)
+            adj.ringModVol += contribution;
+        else if (row.target == SynthParam::ID::NoiseColor)
+            adj.noiseColor += contribution;
+        else if (row.target == SynthParam::ID::OscPitch)
+            adj.oscPitch += contribution;
+        else if (row.target == SynthParam::ID::UnisonDetune)
+            adj.unisonDetune += contribution;
+        else if (row.target == SynthParam::ID::OscPW)
+            adj.oscPW += contribution;
+        else if (row.target == SynthParam::ID::OscCrossmod)
+            adj.crossmod += contribution;
+        else if (row.target == SynthParam::ID::LFO1ModAmount1)
+            adj.lfo1Mod1 += contribution;
+        else if (row.target == SynthParam::ID::LFO1ModAmount2)
+            adj.lfo1Mod2 += contribution;
+        else if (row.target == SynthParam::ID::LFO2Rate)
+            adj.lfo2Rate += contribution;
+        else if (row.target == SynthParam::ID::LFO2ModAmount1)
+            adj.lfo2Mod1 += contribution;
+        else if (row.target == SynthParam::ID::LFO2ModAmount2)
+            adj.lfo2Mod2 += contribution;
+        else if (row.target == SynthParam::ID::FilterEnvAttack)
+            adj.filterEnvAttack += contribution;
+        else if (row.target == SynthParam::ID::FilterEnvRelease)
+            adj.filterEnvRelease += contribution;
+        else if (row.target == SynthParam::ID::AmpEnvAttack)
+            adj.ampEnvAttack += contribution;
+        else if (row.target == SynthParam::ID::AmpEnvRelease)
+            adj.ampEnvRelease += contribution;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Thread-safe UI→audio FIFO for matrix row updates
+// ---------------------------------------------------------------------------
+struct MatrixRowUpdate
+{
+    int index{-1};
+    MatrixRow row{};
+};
+
+/*
+ * MatrixUpdateFifo: single-producer (UI), single-consumer (audio) FIFO for
+ * pushing row edits from the message thread to processBlock.
+ */
+template <int Capacity> class MatrixUpdateFifo
+{
+  public:
+    MatrixUpdateFifo() : abstractFifo(Capacity) {}
+
+    bool push(int index, const MatrixRow &row)
+    {
+        if (abstractFifo.getFreeSpace() == 0)
+            return false;
+        auto scope = abstractFifo.write(1);
+        if (scope.blockSize1 > 0)
+            buffer[scope.startIndex1] = {index, row};
+        else if (scope.blockSize2 > 0)
+            buffer[scope.startIndex2] = {index, row};
+        return true;
+    }
+
+    bool hasElement() const { return abstractFifo.getNumReady() > 0; }
+
+    /* Call only after hasElement() returns true */
+    MatrixRowUpdate pop()
+    {
+        auto scope = abstractFifo.read(1);
+        if (scope.blockSize1 > 0)
+            return buffer[scope.startIndex1];
+        return buffer[scope.startIndex2];
+    }
+
+  private:
+    juce::AbstractFifo abstractFifo;
+    std::array<MatrixRowUpdate, Capacity> buffer{};
+
+    JUCE_DECLARE_NON_COPYABLE(MatrixUpdateFifo)
+    JUCE_DECLARE_NON_MOVEABLE(MatrixUpdateFifo)
+};
+
+// ---------------------------------------------------------------------------
+// Matrix presets — THROWAWAY / for testing only
+// ---------------------------------------------------------------------------
+struct MatrixPreset
+{
+    std::string name;
+    std::array<MatrixRow, numMatrixRows> rows{};
+};
+
+inline std::vector<MatrixPreset> getMatrixPresets()
+{
+    std::vector<MatrixPreset> presets;
+
+    // Preset 1: Timbre → Cutoff
+    {
+        MatrixPreset p;
+        p.name = "Timbre to Cutoff";
+        p.rows[0] = {MatrixSource::Timbre, SynthParam::ID::FilterCutoff, 0.7f};
+        presets.push_back(p);
+    }
+
+    // Preset 2: Pressure → Pitch, Timbre → Cutoff
+    {
+        MatrixPreset p;
+        p.name = "Pressure to Pitch + Timbre to Cutoff";
+        p.rows[0] = {MatrixSource::ChannelPressure, SynthParam::ID::Osc1Pitch, 0.3f};
+        p.rows[1] = {MatrixSource::ChannelPressure, SynthParam::ID::Osc2Pitch, -0.3f};
+        p.rows[2] = {MatrixSource::Timbre, SynthParam::ID::FilterCutoff, 0.7f};
+        presets.push_back(p);
+    }
+
+    // Preset 3: Velocity → Cutoff + Resonance
+    {
+        MatrixPreset p;
+        p.name = "Velocity to Filter";
+        p.rows[0] = {MatrixSource::Velocity, SynthParam::ID::FilterCutoff, 0.5f};
+        p.rows[1] = {MatrixSource::Velocity, SynthParam::ID::FilterResonance, 0.3f};
+        presets.push_back(p);
+    }
+
+    // Preset 4: VoiceBend → Cutoff (expressive filter sweep)
+    {
+        MatrixPreset p;
+        p.name = "Bend to Cutoff";
+        p.rows[0] = {MatrixSource::VoiceBend, SynthParam::ID::FilterCutoff, 0.5f};
+        presets.push_back(p);
+    }
+
+    // Preset 5: Timbre → Osc Mix + Cutoff
+    {
+        MatrixPreset p;
+        p.name = "Timbre to Mix + Cutoff";
+        p.rows[0] = {MatrixSource::Timbre, SynthParam::ID::Osc1Vol, 0.6f};
+        p.rows[1] = {MatrixSource::Timbre, SynthParam::ID::FilterCutoff, 0.4f};
+        presets.push_back(p);
+    }
+
+    return presets;
+}
+
+#endif // OBXF_SRC_ENGINE_VOICEMATRIX_H

--- a/src/gui/LookAndFeel.h
+++ b/src/gui/LookAndFeel.h
@@ -248,6 +248,54 @@ class LookAndFeel final : public juce::LookAndFeel_V4
         return juce::BubbleComponent::BubblePlacement::above;
     }
 
+    // temporary hack for MPE matrix
+    void drawLinearSlider(juce::Graphics &g, int x, int y, int width, int height, float sliderPos,
+                          float minSliderPos, float maxSliderPos, juce::Slider::SliderStyle style,
+                          juce::Slider &slider) override
+    {
+        /* Bipolar sliders (range spans zero) fill from the zero crossing toward the thumb
+         * rather than from the left edge, giving an intuitive +/- visual.
+         */
+        if (style == juce::Slider::LinearHorizontal && slider.getMinimum() == -slider.getMaximum())
+        {
+            constexpr float trackThickness = 4.0f;
+            const float trackY = y + (height - trackThickness) * 0.5f;
+            const auto trackRect = juce::Rectangle<float>(
+                static_cast<float>(x), trackY, static_cast<float>(width), trackThickness);
+
+            g.setColour(
+                slider.findColour(juce::Slider::thumbColourId).darker(0.8f).withAlpha(0.5f));
+            g.fillRect(trackRect);
+
+            const float zeroFrac = static_cast<float>(-slider.getMinimum() /
+                                                      (slider.getMaximum() - slider.getMinimum()));
+            const float zeroX = static_cast<float>(x) + zeroFrac * static_cast<float>(width);
+
+            const auto fillRect =
+                (sliderPos >= zeroX)
+                    ? juce::Rectangle<float>(zeroX, trackY, sliderPos - zeroX, trackThickness)
+                    : juce::Rectangle<float>(sliderPos, trackY, zeroX - sliderPos, trackThickness);
+            g.setColour(slider.findColour(juce::Slider::thumbColourId));
+            g.fillRect(fillRect);
+
+            g.setColour(slider.findColour(juce::Slider::thumbColourId).withAlpha(0.5f));
+            g.drawVerticalLine(juce::roundToInt(zeroX), trackY - 2.f,
+                               trackY + trackThickness + 2.f);
+
+            const float thumbW = 8.0f;
+            const float thumbH = static_cast<float>(height) * 0.65f;
+            g.setColour(slider.findColour(juce::Slider::thumbColourId));
+            g.fillRect(juce::Rectangle<float>(sliderPos - thumbW * 0.5f,
+                                              y + (static_cast<float>(height) - thumbH) * 0.5f,
+                                              thumbW, thumbH));
+        }
+        else
+        {
+            juce::LookAndFeel_V4::drawLinearSlider(g, x, y, width, height, sliderPos, minSliderPos,
+                                                   maxSliderPos, style, slider);
+        }
+    }
+
     juce::PopupMenu::Options getOptionsForComboBoxPopupMenu(juce::ComboBox &b,
                                                             juce::Label &l) override
     {

--- a/src/gui/MPEMatrix.h
+++ b/src/gui/MPEMatrix.h
@@ -1,0 +1,389 @@
+/*
+ * OB-Xf - a continuation of the last open source version of OB-Xd.
+ *
+ * OB-Xd was originally written by Vadim Filatov, and then a version
+ * was released under the GPL3 at https://github.com/reales/OB-Xd.
+ * Subsequently, the product was continued by DiscoDSP and the copyright
+ * holders as an excellent closed source product. For more info,
+ * see "HISTORY.md" in the root of this repository.
+ *
+ * This repository is a successor to the last open source release,
+ * a version marked as 2.11. Copyright 2013-2025 by the authors
+ * as indicated in the original release, and subsequent authors
+ * per the GitHub transaction log.
+ *
+ * OB-Xf is released under the GNU General Public Licence v3 or later
+ * (GPL-3.0-or-later). The license is found in the file "LICENSE"
+ * in the root of this repository or at:
+ * https://www.gnu.org/licenses/gpl-3.0.en.html
+ *
+ * Source code is available at https://github.com/surge-synthesizer/OB-Xf
+ */
+
+/*
+ * MPEMatrix.h — temporary developer UI for the MPE modulation matrix.
+ *
+ * This component uses stock JUCE widgets and is NOT intended for production.
+ * It will be replaced with a properly skinned component before release.
+ * The control layout and callback wiring may survive into the skinned version.
+ */
+
+#ifndef OBXF_SRC_GUI_MPEMATRIX_H
+#define OBXF_SRC_GUI_MPEMATRIX_H
+
+#include <array>
+#include <juce_gui_basics/juce_gui_basics.h>
+
+#include "../PluginProcessor.h"
+#include "../engine/VoiceMatrix.h"
+#include "../parameter/SynthParam.h"
+
+class MPEMatrixEditor : public juce::Component
+{
+  public:
+    explicit MPEMatrixEditor(ObxfAudioProcessor &proc) : processor(proc)
+    {
+        closeButton.onClick = [this] { setVisible(false); };
+        addAndMakeVisible(closeButton);
+
+        for (int i = 0; i < numMatrixRows; ++i)
+        {
+            auto &rc = rowControls[i];
+
+            rc.source = std::make_unique<juce::ComboBox>();
+            rc.source->addItem("None", 1);
+            rc.source->addItem("Voice Bend", 2);
+            rc.source->addItem("Channel Pressure", 3);
+            rc.source->addItem("Timbre", 4);
+            rc.source->addItem("Velocity", 5);
+            rc.source->addItem("Release Velocity", 6);
+            rc.source->addItem("LFO 2", 7);
+            rc.source->onChange = [this, i] { onRowChanged(i); };
+            addAndMakeVisible(*rc.source);
+
+            rc.target = std::make_unique<juce::ComboBox>();
+            rc.target->addItem("---", 1);
+            rc.target->addItem("Filter Cutoff", 2);
+            rc.target->addItem("Filter Resonance", 3);
+            rc.target->addItem("Osc 1 Pitch", 4);
+            rc.target->addItem("Osc 2 Pitch", 5);
+            rc.target->addItem("Osc 2 Detune", 6);
+            rc.target->addItem("Osc 2 PW Offset", 7);
+            rc.target->addItem("Osc 1 Vol", 8);
+            rc.target->addItem("Osc 2 Vol", 9);
+            rc.target->addItem("Noise Vol", 10);
+            rc.target->addItem("Ring Mod Vol", 11);
+            rc.target->addItem("Noise Color", 12);
+            rc.target->addItem("Osc Pitch (Both)", 13);
+            rc.target->addItem("Unison Detune", 14);
+            rc.target->addItem("Osc PW", 15);
+            rc.target->addItem("Crossmod", 16);
+            rc.target->addItem("LFO1 Mod 1", 17);
+            rc.target->addItem("LFO1 Mod 2", 18);
+            rc.target->addItem("LFO2 Rate", 19);
+            rc.target->addItem("LFO2 Mod 1", 20);
+            rc.target->addItem("LFO2 Mod 2", 21);
+            rc.target->addItem("Filter Env A", 22);
+            rc.target->addItem("Filter Env R", 23);
+            rc.target->addItem("Amp Env A", 24);
+            rc.target->addItem("Amp Env R", 25);
+            rc.target->onChange = [this, i] { onRowChanged(i); };
+            addAndMakeVisible(*rc.target);
+
+            rc.depth = std::make_unique<juce::Slider>(juce::Slider::LinearHorizontal,
+                                                      juce::Slider::TextBoxRight);
+            rc.depth->setRange(-1.0, 1.0, 0.01);
+            rc.depth->setDoubleClickReturnValue(true, 0.0);
+            rc.depth->onValueChange = [this, i] { onRowChanged(i); };
+            addAndMakeVisible(*rc.depth);
+        }
+
+        refresh();
+    }
+
+    /*
+     * Re-reads the current matrix state from the processor and updates all controls.
+     * Reading voiceMatrix from the message thread is a benign race for a dev tool.
+     */
+    void refresh()
+    {
+        const auto &vm = processor.getSynth().getMotherboard()->voiceMatrix;
+        for (int i = 0; i < numMatrixRows; ++i)
+            syncRow(i, vm.rows[i]);
+    }
+
+    /* Sync UI directly from a known set of rows (e.g. after a preset push). */
+    void syncUI(const std::array<MatrixRow, numMatrixRows> &rows)
+    {
+        for (int i = 0; i < numMatrixRows; ++i)
+            syncRow(i, rows[i]);
+    }
+
+    void paint(juce::Graphics &g) override
+    {
+        g.fillAll(juce::Colours::black);
+
+        g.setColour(juce::Colour(0xffe0e0d8));
+        g.drawRoundedRectangle(getLocalBounds().toFloat().reduced(1.f), 4.f, 1.5f);
+
+        g.setColour(juce::Colour(0xffe0e0d8));
+        g.setFont(juce::FontOptions(14.f, juce::Font::bold));
+        g.drawText("MPE Matrix - dev editor (temporary)", kPad, kPad, getWidth() - kPad * 2,
+                   kTitleH, juce::Justification::centred);
+
+        g.setColour(juce::Colour(0xffffcc44));
+        g.setFont(juce::FontOptions(11.f));
+        g.drawText("MPE support is alpha.  Changes here may not be compatible with 1.1 release.",
+                   kPad, kPad + kTitleH + kTitleGap, getWidth() - kPad * 2, kWarningH,
+                   juce::Justification::centred);
+
+        g.setColour(juce::Colour(0xff888880));
+        g.setFont(juce::FontOptions(11.f));
+        g.drawText("Source", sourceX(), kColHeaderY, kSourceW, kColHeaderH,
+                   juce::Justification::centredLeft);
+        g.drawText("Target", targetX(), kColHeaderY, kTargetW, kColHeaderH,
+                   juce::Justification::centredLeft);
+        g.drawText("Depth", depthX(), kColHeaderY, kDepthW, kColHeaderH,
+                   juce::Justification::centredLeft);
+    }
+
+    void resized() override
+    {
+        closeButton.setBounds(getWidth() - kPad - kCloseBtnW, kPad, kCloseBtnW, kTitleH);
+
+        for (int i = 0; i < numMatrixRows; ++i)
+        {
+            const int y = rowY(i);
+            auto &rc = rowControls[i];
+            rc.source->setBounds(sourceX(), y, kSourceW, kRowH);
+            rc.target->setBounds(targetX(), y, kTargetW, kRowH);
+            rc.depth->setBounds(depthX(), y, kDepthW, kRowH);
+        }
+    }
+
+    static int preferredWidth()
+    {
+        return kPad + kSourceW + kColGap + kTargetW + kColGap + kDepthW + kPad;
+    }
+    static int preferredHeight() { return rowY(numMatrixRows - 1) + kRowH + kPad; }
+
+  private:
+    ObxfAudioProcessor &processor;
+    juce::TextButton closeButton{"Close"};
+
+    struct RowControls
+    {
+        std::unique_ptr<juce::ComboBox> source;
+        std::unique_ptr<juce::ComboBox> target;
+        std::unique_ptr<juce::Slider> depth;
+    };
+
+    std::array<RowControls, numMatrixRows> rowControls;
+
+    /* Layout constants */
+    static constexpr int kCloseBtnW = 52;
+    static constexpr int kPad = 12;
+    static constexpr int kTitleH = 22;
+    static constexpr int kTitleGap = 4;
+    static constexpr int kWarningH = 16;
+    static constexpr int kWarningGap = 8;
+    static constexpr int kColHeaderH = 20;
+    static constexpr int kColHeaderGap = 4;
+    static constexpr int kRowH = 26;
+    static constexpr int kRowGap = 6;
+    static constexpr int kSourceW = 130;
+    static constexpr int kTargetW = 145;
+    static constexpr int kDepthW = 185;
+    static constexpr int kColGap = 8;
+
+    static constexpr int kColHeaderY = kPad + kTitleH + kTitleGap + kWarningH + kWarningGap;
+    static constexpr int kFirstRowY = kColHeaderY + kColHeaderH + kColHeaderGap;
+
+    static int sourceX() { return kPad; }
+    static int targetX() { return sourceX() + kSourceW + kColGap; }
+    static int depthX() { return targetX() + kTargetW + kColGap; }
+    static int rowY(int i) { return kFirstRowY + i * (kRowH + kRowGap); }
+
+    void syncRow(int i, const MatrixRow &row)
+    {
+        auto &rc = rowControls[i];
+        rc.source->onChange = nullptr;
+        rc.target->onChange = nullptr;
+        rc.depth->onValueChange = nullptr;
+
+        rc.source->setSelectedId(sourceToId(row.source), juce::dontSendNotification);
+        rc.target->setSelectedId(targetToId(row.target), juce::dontSendNotification);
+        rc.depth->setValue(row.depth, juce::dontSendNotification);
+
+        rc.source->onChange = [this, i] { onRowChanged(i); };
+        rc.target->onChange = [this, i] { onRowChanged(i); };
+        rc.depth->onValueChange = [this, i] { onRowChanged(i); };
+    }
+
+    void onRowChanged(int idx)
+    {
+        auto &rc = rowControls[idx];
+        MatrixRow row;
+        row.source = idToSource(rc.source->getSelectedId());
+        row.target = idToTarget(rc.target->getSelectedId());
+        row.depth = static_cast<float>(rc.depth->getValue());
+        processor.pushMatrixRowUpdate(idx, row);
+    }
+
+    static int sourceToId(MatrixSource s)
+    {
+        switch (s)
+        {
+        case MatrixSource::VoiceBend:
+            return 2;
+        case MatrixSource::ChannelPressure:
+            return 3;
+        case MatrixSource::Timbre:
+            return 4;
+        case MatrixSource::Velocity:
+            return 5;
+        case MatrixSource::ReleaseVelocity:
+            return 6;
+        case MatrixSource::LFO2:
+            return 7;
+        case MatrixSource::None:
+        default:
+            return 1;
+        }
+    }
+
+    static MatrixSource idToSource(int id)
+    {
+        switch (id)
+        {
+        case 2:
+            return MatrixSource::VoiceBend;
+        case 3:
+            return MatrixSource::ChannelPressure;
+        case 4:
+            return MatrixSource::Timbre;
+        case 5:
+            return MatrixSource::Velocity;
+        case 6:
+            return MatrixSource::ReleaseVelocity;
+        case 7:
+            return MatrixSource::LFO2;
+        default:
+            return MatrixSource::None;
+        }
+    }
+
+    static int targetToId(const std::string &t)
+    {
+        if (t == SynthParam::ID::FilterCutoff)
+            return 2;
+        if (t == SynthParam::ID::FilterResonance)
+            return 3;
+        if (t == SynthParam::ID::Osc1Pitch)
+            return 4;
+        if (t == SynthParam::ID::Osc2Pitch)
+            return 5;
+        if (t == SynthParam::ID::Osc2Detune)
+            return 6;
+        if (t == SynthParam::ID::Osc2PWOffset)
+            return 7;
+        if (t == SynthParam::ID::Osc1Vol)
+            return 8;
+        if (t == SynthParam::ID::Osc2Vol)
+            return 9;
+        if (t == SynthParam::ID::NoiseVol)
+            return 10;
+        if (t == SynthParam::ID::RingModVol)
+            return 11;
+        if (t == SynthParam::ID::NoiseColor)
+            return 12;
+        if (t == SynthParam::ID::OscPitch)
+            return 13;
+        if (t == SynthParam::ID::UnisonDetune)
+            return 14;
+        if (t == SynthParam::ID::OscPW)
+            return 15;
+        if (t == SynthParam::ID::OscCrossmod)
+            return 16;
+        if (t == SynthParam::ID::LFO1ModAmount1)
+            return 17;
+        if (t == SynthParam::ID::LFO1ModAmount2)
+            return 18;
+        if (t == SynthParam::ID::LFO2Rate)
+            return 19;
+        if (t == SynthParam::ID::LFO2ModAmount1)
+            return 20;
+        if (t == SynthParam::ID::LFO2ModAmount2)
+            return 21;
+        if (t == SynthParam::ID::FilterEnvAttack)
+            return 22;
+        if (t == SynthParam::ID::FilterEnvRelease)
+            return 23;
+        if (t == SynthParam::ID::AmpEnvAttack)
+            return 24;
+        if (t == SynthParam::ID::AmpEnvRelease)
+            return 25;
+        return 1;
+    }
+
+    static std::string idToTarget(int id)
+    {
+        switch (id)
+        {
+        case 2:
+            return SynthParam::ID::FilterCutoff;
+        case 3:
+            return SynthParam::ID::FilterResonance;
+        case 4:
+            return SynthParam::ID::Osc1Pitch;
+        case 5:
+            return SynthParam::ID::Osc2Pitch;
+        case 6:
+            return SynthParam::ID::Osc2Detune;
+        case 7:
+            return SynthParam::ID::Osc2PWOffset;
+        case 8:
+            return SynthParam::ID::Osc1Vol;
+        case 9:
+            return SynthParam::ID::Osc2Vol;
+        case 10:
+            return SynthParam::ID::NoiseVol;
+        case 11:
+            return SynthParam::ID::RingModVol;
+        case 12:
+            return SynthParam::ID::NoiseColor;
+        case 13:
+            return SynthParam::ID::OscPitch;
+        case 14:
+            return SynthParam::ID::UnisonDetune;
+        case 15:
+            return SynthParam::ID::OscPW;
+        case 16:
+            return SynthParam::ID::OscCrossmod;
+        case 17:
+            return SynthParam::ID::LFO1ModAmount1;
+        case 18:
+            return SynthParam::ID::LFO1ModAmount2;
+        case 19:
+            return SynthParam::ID::LFO2Rate;
+        case 20:
+            return SynthParam::ID::LFO2ModAmount1;
+        case 21:
+            return SynthParam::ID::LFO2ModAmount2;
+        case 22:
+            return SynthParam::ID::FilterEnvAttack;
+        case 23:
+            return SynthParam::ID::FilterEnvRelease;
+        case 24:
+            return SynthParam::ID::AmpEnvAttack;
+        case 25:
+            return SynthParam::ID::AmpEnvRelease;
+        default:
+            return {};
+        }
+    }
+
+    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(MPEMatrixEditor)
+};
+
+#endif // OBXF_SRC_GUI_MPEMATRIX_H

--- a/src/midi/MidiHandler.cpp
+++ b/src/midi/MidiHandler.cpp
@@ -110,7 +110,8 @@ void MidiHandler::processMidiPerSample(juce::MidiBufferIterator *iter,
             continue;
 
         const auto status = data[0] & 0xF0;
-        if (status != 0x80 && status != 0x90 && status != 0xB0 && status != 0xC0 && status != 0xE0)
+        if (status != 0x80 && status != 0x90 && status != 0xB0 && status != 0xC0 &&
+            status != 0xD0 && status != 0xE0)
             continue;
 
         // DBG("Valid Message: " << (int)midiMsg->getChannel() << " "
@@ -130,8 +131,25 @@ void MidiHandler::processMidiPerSample(juce::MidiBufferIterator *iter,
         }
         if (midiMsg->isPitchWheel())
         {
-            synth.processPitchWheel((midiMsg->getPitchWheelValue() - 8192) / 8192.0f);
+            const float pitchVal = (midiMsg->getPitchWheelValue() - 8192) / 8192.0f;
+            if (mpeEnabled.load() && midiMsg->getChannel() != 1)
+            {
+                synth.processMPEPitch(static_cast<int8_t>(midiMsg->getChannel() - 1), pitchVal);
+            }
+            else
+            {
+                synth.processPitchWheel(pitchVal);
+            }
         }
+        if (midiMsg->isChannelPressure())
+        {
+            if (mpeEnabled.load() && midiMsg->getChannel() != 1)
+            {
+                synth.processMPEChannelPressure(static_cast<int8_t>(midiMsg->getChannel() - 1),
+                                                midiMsg->getChannelPressureValue() / 127.0f);
+            }
+        }
+
         if (midiMsg->isController())
         {
             bool dontLearn = false;
@@ -147,7 +165,16 @@ void MidiHandler::processMidiPerSample(juce::MidiBufferIterator *iter,
                 dontLearn = true;
                 break;
             case 64:
+                dontLearn = true;
+                break;
             case 74:
+                if (mpeEnabled.load() && midiMsg->getChannel() != 1)
+                {
+                    synth.processMPETimbre(static_cast<int8_t>(midiMsg->getChannel() - 1),
+                                           midiMsg->getControllerValue() / 127.0f);
+                }
+                dontLearn = true;
+                break;
             case 120:
             case 123:
                 dontLearn = true;

--- a/src/midi/MidiHandler.h
+++ b/src/midi/MidiHandler.h
@@ -84,6 +84,12 @@ class MidiHandler
     std::atomic<bool> midiControlledParamSet{false};
     int lastMovedController{0};
     std::atomic<int> lastUsedParameter{0};
+
+  public:
+    std::atomic<bool> mpeEnabled{false};
+    std::atomic<int> mpePitchBendRange{48};
+
+  private:
     int midiEventPos{0};
     uint8_t bankSelectMSB{0};
 

--- a/src/parameter/SynthParam.h
+++ b/src/parameter/SynthParam.h
@@ -50,6 +50,8 @@ static const std::string EnvLegatoMode{"EnvLegatoMode"};
 static const std::string NotePriority{"NotePriority"};
 
 // OSCILLATORS
+static const std::string OscPitch{
+    "OscPitch"}; // matrix routing: both Osc1+Osc2 pitch (no JUCE parameter)
 static const std::string Osc1Pitch{"Osc1Pitch"};
 static const std::string Osc2Detune{"Osc2Detune"};
 static const std::string Osc2Pitch{"Osc2Pitch"};

--- a/src/state/StateManager.cpp
+++ b/src/state/StateManager.cpp
@@ -75,6 +75,9 @@ void StateManager::getActiveProgramStateOnto(juce::XmlElement &xmlState) const
 
     xmlState.setAttribute(S("voiceCount"), MAX_VOICES);
     xmlState.setAttribute(S("programName"), prog.getName());
+
+    auto vmEl = audioProcessor->getSynth().getMotherboard()->voiceMatrix.toElement();
+    xmlState.addChildElement(vmEl.release());
     xmlState.setAttribute(S("author"), prog.getAuthor());
     xmlState.setAttribute(S("license"), prog.getLicense());
     xmlState.setAttribute(S("category"), prog.getCategory());
@@ -167,6 +170,9 @@ void StateManager::setActiveProgramStateFrom(const juce::XmlElement &pnode, uint
     program.setLicense(pnode.getStringAttribute(S("license"), S("")));
     program.setCategory(pnode.getStringAttribute(S("category"), S("")));
     program.setProject(pnode.getStringAttribute(S("project"), S("")));
+
+    audioProcessor->getSynth().getMotherboard()->voiceMatrix.fromElement(
+        pnode.getChildByName("VoiceMatrix"));
 }
 
 bool StateManager::loadFromMemoryBlock(juce::MemoryBlock &mb)
@@ -209,6 +215,10 @@ void StateManager::collectDAWExtraStateFromInstance()
     dawExtraState.controllers = mmap.controllers;
     dawExtraState.selectedLFOIndex = audioProcessor->selectedLFOIndex;
     dawExtraState.impliedScaleFactor = audioProcessor->lastImpliedScaleFactor;
+
+    auto &mh = audioProcessor->getMidiHandler();
+    dawExtraState.mpeEnabled = mh.mpeEnabled.load();
+    dawExtraState.mpePitchBendRange = mh.mpePitchBendRange.load();
 }
 
 void StateManager::applyDAWExtraStateToInstance()
@@ -222,6 +232,9 @@ void StateManager::applyDAWExtraStateToInstance()
 
     audioProcessor->selectedLFOIndex = dawExtraState.selectedLFOIndex;
     audioProcessor->lastImpliedScaleFactor = dawExtraState.impliedScaleFactor;
+
+    audioProcessor->setMpeEnabled(dawExtraState.mpeEnabled);
+    audioProcessor->setMpePitchBendRange(dawExtraState.mpePitchBendRange);
 }
 
 void StateManager::DAWExtraState::fromElement(const juce::XmlElement *e)
@@ -240,6 +253,9 @@ void StateManager::DAWExtraState::fromElement(const juce::XmlElement *e)
 
     selectedLFOIndex = e->getIntAttribute("selectedLFOIndex", 0);
     impliedScaleFactor = e->getDoubleAttribute("impliedScaleFactor", 1.0);
+
+    mpeEnabled = e->getBoolAttribute("mpeEnabled", false);
+    mpePitchBendRange = e->getIntAttribute("mpePitchBendRange", 48);
 }
 
 std::unique_ptr<juce::XmlElement> StateManager::DAWExtraState::toElement() const
@@ -258,5 +274,9 @@ std::unique_ptr<juce::XmlElement> StateManager::DAWExtraState::toElement() const
 
     res->setAttribute("selectedLFOIndex", selectedLFOIndex);
     res->setAttribute("impliedScaleFactor", impliedScaleFactor);
+
+    res->setAttribute("mpeEnabled", mpeEnabled);
+    res->setAttribute("mpePitchBendRange", mpePitchBendRange);
+
     return res;
 }

--- a/src/state/StateManager.h
+++ b/src/state/StateManager.h
@@ -90,6 +90,9 @@ class StateManager final
         uint8_t selectedLFOIndex{0};
         float impliedScaleFactor{1.f};
 
+        bool mpeEnabled{false};
+        int mpePitchBendRange{48};
+
         std::unique_ptr<juce::XmlElement> toElement() const;
         void fromElement(const juce::XmlElement *e);
     } dawExtraState;

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -7,6 +7,7 @@ target_sources(obxf-tests PRIVATE
     filt.cpp
     env.cpp
     noise.cpp
+    mpe.cpp
 )
 
 target_include_directories(obxf-tests PRIVATE

--- a/src/tests/mpe.cpp
+++ b/src/tests/mpe.cpp
@@ -1,0 +1,479 @@
+/*
+ * OB-Xf - a continuation of the last open source version of OB-Xd.
+ *
+ * OB-Xd was originally written by Vadim Filatov, and then a version
+ * was released under the GPL3 at https://github.com/reales/OB-Xd.
+ * Subsequently, the product was continued by DiscoDSP and the copyright
+ * holders as an excellent closed source product. For more info,
+ * see "HISTORY.md" in the root of this repository.
+ *
+ * This repository is a successor to the last open source release,
+ * a version marked as 2.11. Copyright 2013-2025 by the authors
+ * as indicated in the original release, and subsequent authors
+ * per the GitHub transaction log.
+ *
+ * OB-Xf is released under the GNU General Public Licence v3 or later
+ * (GPL-3.0-or-later). The license is found in the file "LICENSE"
+ * in the root of this repository or at:
+ * https://www.gnu.org/licenses/gpl-3.0.en.html
+ *
+ * Source code is available at https://github.com/surge-synthesizer/OB-Xf
+ */
+
+/*
+ * Include SynthEngine.h first so the include chain resolves correctly —
+ * same pattern as osc.cpp and filt.cpp.
+ */
+#include "SynthEngine.h"
+
+#define CATCH_CONFIG_ENABLE_BENCHMARKING
+#include <catch2/catch2.hpp>
+
+#include <cmath>
+#include <string>
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+/* Approximate equality. */
+static bool approxEq(float a, float b, float tol = 1e-5f) { return std::abs(a - b) <= tol; }
+
+/* Minimal engine set up for MPE testing. Polyphony=8, mpeEnabled=true. */
+struct MpeEngine
+{
+    SynthEngine eng;
+    Motherboard *mb;
+
+    MpeEngine()
+    {
+        eng.setSampleRate(44100.f);
+        mb = eng.getMotherboard();
+        mb->setPolyphony(8);
+        mb->mpeEnabled = true;
+    }
+
+    /* First gated voice on the given channel, or nullptr. */
+    Voice *gatedOnChannel(int8_t ch) const
+    {
+        for (int i = 0; i < MAX_VOICES; ++i)
+            if (mb->voices[i].isGated() && mb->voices[i].channel == ch)
+                return &mb->voices[i];
+        return nullptr;
+    }
+
+    /* Total number of currently gated voices. */
+    int gatedCount() const
+    {
+        int n = 0;
+        for (int i = 0; i < MAX_VOICES; ++i)
+            if (mb->voices[i].isGated())
+                ++n;
+        return n;
+    }
+};
+
+// ===========================================================================
+// Layer 1: Pure VoiceMatrix unit tests (no engine required)
+// ===========================================================================
+
+TEST_CASE("VoiceMatrix: single row Velocity->FilterCutoff depth 0.5, source 1.0", "[VoiceMatrix]")
+{
+    VoiceMatrix vm;
+    REQUIRE(vm.setModulation("Velocity", SynthParam::ID::FilterCutoff, 0.5f, 0));
+
+    VoiceMatrixSourceValues src;
+    src.velocity = 1.0f;
+    VoiceMatrixAdjustments adj;
+    recalculateMatrix(vm, src, adj);
+
+    /* contribution = 1.0 * 0.5 = 0.5; range scaling happens at point of use in ProcessSample */
+    REQUIRE(approxEq(adj.filterCutoff, 0.5f));
+    REQUIRE(approxEq(adj.filterResonance, 0.f));
+    REQUIRE(approxEq(adj.osc1Pitch, 0.f));
+}
+
+TEST_CASE("VoiceMatrix: two rows targeting the same param accumulate", "[VoiceMatrix]")
+{
+    VoiceMatrix vm;
+    REQUIRE(vm.setModulation("Velocity", SynthParam::ID::FilterCutoff, 0.3f, 0));
+    REQUIRE(vm.setModulation("Timbre", SynthParam::ID::FilterCutoff, 0.4f, 1));
+
+    VoiceMatrixSourceValues src;
+    src.velocity = 1.0f;
+    src.timbre = 1.0f;
+    VoiceMatrixAdjustments adj;
+    recalculateMatrix(vm, src, adj);
+
+    REQUIRE(approxEq(adj.filterCutoff, 0.7f)); /* 0.3 + 0.4 */
+}
+
+TEST_CASE("VoiceMatrix: depth zero contributes nothing", "[VoiceMatrix]")
+{
+    VoiceMatrix vm;
+    REQUIRE(vm.setModulation("Velocity", SynthParam::ID::FilterCutoff, 0.f, 0));
+
+    VoiceMatrixSourceValues src;
+    src.velocity = 1.0f;
+    VoiceMatrixAdjustments adj;
+    recalculateMatrix(vm, src, adj);
+
+    REQUIRE(approxEq(adj.filterCutoff, 0.f));
+}
+
+TEST_CASE("VoiceMatrix: source value zero contributes nothing", "[VoiceMatrix]")
+{
+    VoiceMatrix vm;
+    REQUIRE(vm.setModulation("Velocity", SynthParam::ID::FilterCutoff, 1.0f, 0));
+
+    VoiceMatrixSourceValues src; /* velocity defaults to 0 */
+    VoiceMatrixAdjustments adj;
+    recalculateMatrix(vm, src, adj);
+
+    REQUIRE(approxEq(adj.filterCutoff, 0.f));
+}
+
+TEST_CASE("VoiceMatrix: negative depth inverts the adjustment", "[VoiceMatrix]")
+{
+    VoiceMatrix vm;
+    REQUIRE(vm.setModulation("Velocity", SynthParam::ID::FilterCutoff, -0.5f, 0));
+
+    VoiceMatrixSourceValues src;
+    src.velocity = 1.0f;
+    VoiceMatrixAdjustments adj;
+    recalculateMatrix(vm, src, adj);
+
+    REQUIRE(approxEq(adj.filterCutoff, -0.5f));
+}
+
+TEST_CASE("VoiceMatrix: setModulation rejects unknown source string", "[VoiceMatrix]")
+{
+    VoiceMatrix vm;
+    REQUIRE_FALSE(vm.setModulation("Aftertouch", SynthParam::ID::FilterCutoff, 1.f, 0));
+    REQUIRE_FALSE(vm.rows[0].isActive());
+}
+
+TEST_CASE("VoiceMatrix: setModulation rejects unknown target string", "[VoiceMatrix]")
+{
+    VoiceMatrix vm;
+    REQUIRE_FALSE(vm.setModulation("Velocity", "NonExistentParam", 1.f, 0));
+    REQUIRE_FALSE(vm.rows[0].isActive());
+}
+
+TEST_CASE("VoiceMatrix: setModulation rejects out-of-range index", "[VoiceMatrix]")
+{
+    VoiceMatrix vm;
+    REQUIRE_FALSE(vm.setModulation("Velocity", SynthParam::ID::FilterCutoff, 1.f, numMatrixRows));
+    REQUIRE_FALSE(vm.setModulation("Velocity", SynthParam::ID::FilterCutoff, 1.f, -1));
+}
+
+TEST_CASE("VoiceMatrix: isLFO2Bound cache tracks LFO2 row presence", "[VoiceMatrix]")
+{
+    VoiceMatrix vm;
+    REQUIRE_FALSE(vm.isLFO2Bound);
+
+    REQUIRE(vm.setModulation("LFO2", SynthParam::ID::FilterCutoff, 1.f, 0));
+    REQUIRE(vm.isLFO2Bound);
+
+    /* Adding a non-LFO2 row: still bound */
+    REQUIRE(vm.setModulation("Velocity", SynthParam::ID::FilterResonance, 0.5f, 1));
+    REQUIRE(vm.isLFO2Bound);
+
+    /* Clearing the LFO2 row: no longer bound */
+    vm.clearRow(0);
+    REQUIRE_FALSE(vm.isLFO2Bound);
+}
+
+TEST_CASE("VoiceMatrix: non-LFO2 row does not set isLFO2Bound", "[VoiceMatrix]")
+{
+    VoiceMatrix vm;
+    REQUIRE(vm.setModulation("Velocity", SynthParam::ID::FilterCutoff, 1.f, 0));
+    REQUIRE_FALSE(vm.isLFO2Bound);
+}
+
+TEST_CASE("VoiceMatrix: XML round-trip preserves all active rows", "[VoiceMatrix]")
+{
+    VoiceMatrix vm;
+    REQUIRE(vm.setModulation("Velocity", SynthParam::ID::FilterCutoff, 0.5f, 0));
+    REQUIRE(vm.setModulation("Timbre", SynthParam::ID::Osc1Pitch, -0.3f, 1));
+    REQUIRE(vm.setModulation("ChannelPressure", SynthParam::ID::FilterResonance, 0.7f, 2));
+
+    auto el = vm.toElement();
+
+    VoiceMatrix vm2;
+    vm2.fromElement(el.get());
+
+    REQUIRE(vm2.rows[0].source == MatrixSource::Velocity);
+    REQUIRE(vm2.rows[0].target == SynthParam::ID::FilterCutoff);
+    REQUIRE(approxEq(vm2.rows[0].depth, 0.5f));
+
+    REQUIRE(vm2.rows[1].source == MatrixSource::Timbre);
+    REQUIRE(vm2.rows[1].target == SynthParam::ID::Osc1Pitch);
+    REQUIRE(approxEq(vm2.rows[1].depth, -0.3f));
+
+    REQUIRE(vm2.rows[2].source == MatrixSource::ChannelPressure);
+    REQUIRE(vm2.rows[2].target == SynthParam::ID::FilterResonance);
+    REQUIRE(approxEq(vm2.rows[2].depth, 0.7f));
+
+    /* Unused rows remain inactive */
+    for (int i = 3; i < numMatrixRows; ++i)
+        REQUIRE_FALSE(vm2.rows[i].isActive());
+}
+
+TEST_CASE("VoiceMatrix: fromElement with nullptr clears all rows", "[VoiceMatrix]")
+{
+    VoiceMatrix vm;
+    REQUIRE(vm.setModulation("Velocity", SynthParam::ID::FilterCutoff, 1.f, 0));
+
+    vm.fromElement(nullptr);
+
+    for (int i = 0; i < numMatrixRows; ++i)
+        REQUIRE_FALSE(vm.rows[i].isActive());
+    REQUIRE_FALSE(vm.isLFO2Bound);
+}
+
+TEST_CASE("VoiceMatrix: clear() resets rows and cache", "[VoiceMatrix]")
+{
+    VoiceMatrix vm;
+    REQUIRE(vm.setModulation("LFO2", SynthParam::ID::FilterCutoff, 1.f, 0));
+    REQUIRE(vm.isLFO2Bound);
+
+    vm.clear();
+
+    REQUIRE_FALSE(vm.isLFO2Bound);
+    for (int i = 0; i < numMatrixRows; ++i)
+        REQUIRE_FALSE(vm.rows[i].isActive());
+}
+
+TEST_CASE("VoiceMatrix: VoiceMatrixSourceValues get/set round-trips all sources", "[VoiceMatrix]")
+{
+    VoiceMatrixSourceValues src;
+    src.set(MatrixSource::VoiceBend, 0.1f);
+    src.set(MatrixSource::ChannelPressure, 0.2f);
+    src.set(MatrixSource::Timbre, 0.3f);
+    src.set(MatrixSource::Velocity, 0.4f);
+    src.set(MatrixSource::ReleaseVelocity, 0.5f);
+    src.set(MatrixSource::LFO2, 0.6f);
+
+    REQUIRE(approxEq(src.get(MatrixSource::VoiceBend), 0.1f));
+    REQUIRE(approxEq(src.get(MatrixSource::ChannelPressure), 0.2f));
+    REQUIRE(approxEq(src.get(MatrixSource::Timbre), 0.3f));
+    REQUIRE(approxEq(src.get(MatrixSource::Velocity), 0.4f));
+    REQUIRE(approxEq(src.get(MatrixSource::ReleaseVelocity), 0.5f));
+    REQUIRE(approxEq(src.get(MatrixSource::LFO2), 0.6f));
+    REQUIRE(approxEq(src.get(MatrixSource::None), 0.f));
+}
+
+// ===========================================================================
+// Layer 2: Motherboard integration tests
+// ===========================================================================
+
+/*
+ * NOTE: NoteOn does not check channel during voice allocation — two notes on
+ * the same pitch number but different channels will retrigger the same voice.
+ * The tests below use different note numbers where channel isolation matters.
+ */
+
+TEST_CASE("MPE: channel is recorded on the voice at NoteOn", "[MPE][Motherboard]")
+{
+    MpeEngine e;
+    e.eng.processNoteOn(60, 0.7f, 5);
+
+    Voice *v = e.gatedOnChannel(5);
+    REQUIRE(v != nullptr);
+    REQUIRE(v->midiNote == 60);
+    REQUIRE(v->channel == 5);
+}
+
+TEST_CASE("MPE: NoteOff on channel releases only that channel's voice", "[MPE][Motherboard]")
+{
+    MpeEngine e;
+    /* Different notes so NoteOn does not retrigger the same voice */
+    e.eng.processNoteOn(60, 0.8f, 2);
+    e.eng.processNoteOn(62, 0.8f, 3);
+
+    REQUIRE(e.gatedCount() == 2);
+
+    e.eng.processNoteOff(60, 0.f, 2);
+
+    REQUIRE(e.gatedOnChannel(2) == nullptr);
+    REQUIRE(e.gatedOnChannel(3) != nullptr);
+}
+
+TEST_CASE("MPE: processMPEPitch sets voiceBend on the matching channel only", "[MPE][Motherboard]")
+{
+    MpeEngine e;
+    e.eng.processNoteOn(60, 0.5f, 2);
+    e.eng.processNoteOn(62, 0.5f, 3);
+
+    e.mb->processMPEPitch(2, 1.0f);
+
+    Voice *v2 = e.gatedOnChannel(2);
+    Voice *v3 = e.gatedOnChannel(3);
+    REQUIRE(v2 != nullptr);
+    REQUIRE(v3 != nullptr);
+
+    REQUIRE(approxEq(v2->matrixSourceValues.voiceBend, 1.0f));
+    REQUIRE(approxEq(v3->matrixSourceValues.voiceBend, 0.f)); /* untouched */
+}
+
+TEST_CASE("MPE: processMPEPitch scales mpeBend by mpePitchBendRange", "[MPE][Motherboard]")
+{
+    MpeEngine e;
+    e.mb->mpePitchBendRange = 48;
+    e.eng.processNoteOn(60, 0.5f, 2);
+
+    e.mb->processMPEPitch(2, 1.0f);
+
+    Voice *v = e.gatedOnChannel(2);
+    REQUIRE(v != nullptr);
+    REQUIRE(approxEq(v->mpeBend, 48.f));
+}
+
+TEST_CASE("MPE: processMPEPitch negative bend produces negative mpeBend", "[MPE][Motherboard]")
+{
+    MpeEngine e;
+    e.mb->mpePitchBendRange = 48;
+    e.eng.processNoteOn(60, 0.5f, 2);
+
+    e.mb->processMPEPitch(2, -1.0f);
+
+    Voice *v = e.gatedOnChannel(2);
+    REQUIRE(v != nullptr);
+    REQUIRE(approxEq(v->mpeBend, -48.f));
+}
+
+TEST_CASE("MPE: processMPETimbre normalises 0..1 to -1..1", "[MPE][Motherboard]")
+{
+    MpeEngine e;
+    e.eng.processNoteOn(60, 0.5f, 4);
+    Voice *v = e.gatedOnChannel(4);
+    REQUIRE(v != nullptr);
+
+    e.mb->processMPETimbre(4, 0.f);
+    REQUIRE(approxEq(v->matrixSourceValues.timbre, -1.f));
+
+    e.mb->processMPETimbre(4, 0.5f);
+    REQUIRE(approxEq(v->matrixSourceValues.timbre, 0.f));
+
+    e.mb->processMPETimbre(4, 1.f);
+    REQUIRE(approxEq(v->matrixSourceValues.timbre, 1.f));
+}
+
+TEST_CASE("MPE: processMPEChannelPressure normalises 0..1 to -1..1", "[MPE][Motherboard]")
+{
+    MpeEngine e;
+    e.eng.processNoteOn(60, 0.5f, 6);
+    Voice *v = e.gatedOnChannel(6);
+    REQUIRE(v != nullptr);
+
+    e.mb->processMPEChannelPressure(6, 0.f);
+    REQUIRE(approxEq(v->matrixSourceValues.channelPressure, -1.f));
+
+    e.mb->processMPEChannelPressure(6, 0.5f);
+    REQUIRE(approxEq(v->matrixSourceValues.channelPressure, 0.f));
+
+    e.mb->processMPEChannelPressure(6, 1.f);
+    REQUIRE(approxEq(v->matrixSourceValues.channelPressure, 1.f));
+}
+
+TEST_CASE("MPE: velocity is stored in matrixSourceValues at NoteOn", "[MPE][Motherboard]")
+{
+    MpeEngine e;
+
+    e.eng.processNoteOn(60, 1.0f, 2);
+    Voice *v = e.gatedOnChannel(2);
+    REQUIRE(v != nullptr);
+    REQUIRE(approxEq(v->matrixSourceValues.velocity, 1.f));
+    e.eng.processNoteOff(60, 0.f, 2);
+
+    e.eng.processNoteOn(60, 0.5f, 2);
+    Voice *v2 = e.gatedOnChannel(2);
+    REQUIRE(v2 != nullptr);
+    REQUIRE(approxEq(v2->matrixSourceValues.velocity, 0.5f));
+}
+
+TEST_CASE("MPE: release velocity is stored in matrixSourceValues at NoteOff", "[MPE][Motherboard]")
+{
+    MpeEngine e;
+    e.eng.processNoteOn(60, 0.8f, 3);
+    Voice *v = e.gatedOnChannel(3);
+    REQUIRE(v != nullptr);
+
+    /* Capture before NoteOff since the voice ungates */
+    e.eng.processNoteOff(60, 0.5f, 3);
+
+    REQUIRE(approxEq(v->matrixSourceValues.releaseVelocity, 0.5f));
+}
+
+TEST_CASE("MPE: matrix adjustment is computed from velocity immediately at NoteOn",
+          "[MPE][Motherboard]")
+{
+    MpeEngine e;
+    e.mb->voiceMatrix.setModulation("Velocity", SynthParam::ID::FilterCutoff, 1.f, 0);
+
+    e.eng.processNoteOn(60, 1.0f, 2);
+    Voice *v = e.gatedOnChannel(2);
+    REQUIRE(v != nullptr);
+
+    /* adj = velocity(1.0) * depth(1.0) = 1.0 */
+    REQUIRE(approxEq(v->matrixAdjustments.filterCutoff, 1.f));
+}
+
+TEST_CASE("MPE: matrix adjustment updates when an MPE message is received", "[MPE][Motherboard]")
+{
+    MpeEngine e;
+    e.mb->voiceMatrix.setModulation("Timbre", SynthParam::ID::FilterCutoff, 1.f, 0);
+
+    e.eng.processNoteOn(60, 0.5f, 2);
+    Voice *v = e.gatedOnChannel(2);
+    REQUIRE(v != nullptr);
+
+    /* Full timbre: normalised = 2*1.0 - 1 = 1.0 → adj = 1.0 * 1.0 = 1.0 */
+    e.mb->processMPETimbre(2, 1.f);
+    REQUIRE(approxEq(v->matrixAdjustments.filterCutoff, 1.f));
+
+    /* Zero timbre: normalised = 2*0.0 - 1 = -1.0 → adj = -1.0 * 1.0 = -1.0 */
+    e.mb->processMPETimbre(2, 0.f);
+    REQUIRE(approxEq(v->matrixAdjustments.filterCutoff, -1.f));
+}
+
+TEST_CASE("MPE: mpeBend is reset to zero on NoteOn (no bleed from previous note)",
+          "[MPE][Motherboard]")
+{
+    MpeEngine e;
+    e.eng.processNoteOn(60, 0.5f, 2);
+
+    /* Apply a non-zero bend */
+    e.mb->processMPEPitch(2, 1.0f);
+    Voice *v = e.gatedOnChannel(2);
+    REQUIRE(v != nullptr);
+    REQUIRE(v->mpeBend != 0.f);
+
+    /* Release, then retrigger same channel — NoteOn must zero mpeBend */
+    e.eng.processNoteOff(60, 0.f, 2);
+    e.eng.processNoteOn(60, 0.5f, 2);
+
+    Voice *v2 = e.gatedOnChannel(2);
+    REQUIRE(v2 != nullptr);
+    REQUIRE(approxEq(v2->mpeBend, 0.f));
+}
+
+TEST_CASE("MPE: matrix adjustments are cleared on NoteOn", "[MPE][Motherboard]")
+{
+    MpeEngine e;
+    /* Wire Timbre → FilterCutoff so adjustments are nonzero after timbre message */
+    e.mb->voiceMatrix.setModulation("Timbre", SynthParam::ID::FilterCutoff, 1.f, 0);
+
+    e.eng.processNoteOn(60, 0.5f, 2);
+    e.mb->processMPETimbre(2, 1.f); /* adj.filterCutoff becomes 1.0 */
+
+    e.eng.processNoteOff(60, 0.f, 2);
+    e.eng.processNoteOn(60, 0.5f, 2); /* fresh note: timbre source cleared → adj reset */
+
+    Voice *v = e.gatedOnChannel(2);
+    REQUIRE(v != nullptr);
+    /* Timbre source value was cleared; only Velocity contributes, not Timbre */
+    REQUIRE(approxEq(v->matrixSourceValues.timbre, 0.f));
+    REQUIRE(approxEq(v->matrixAdjustments.filterCutoff, 0.f));
+}


### PR DESCRIPTION
- `mpeEnabled` flag (persisted in DAW extra state) gates all MPE behaviour
- Per-voice MIDI channel tracking: `Voice::channel` stored at note-on
- Channel-aware NoteOff: in MPE mode, release only matches note AND channel
- `Motherboard::processMPEPitch` — per-channel pitch bend → `mpeBend` + VoiceBend matrix source
- `Motherboard::processMPETimbre` — CC74 (0–1) normalised to −1..1 → Timbre source
- `Motherboard::processMPEChannelPressure` — aftertouch normalised to −1..1 → ChannelPressure source
- `mpePitchBendRange` (default 48 semitones) persisted in DAW state
- Channel pressure MIDI status byte (0xD0) added to the processMidi accept list

- `VoiceMatrix` — fixed-size array of `MatrixRow` (source / target / depth); lives on Motherboard
- Sources: VoiceBend, ChannelPressure, Timbre, Velocity, ReleaseVelocity, LFO2
- Targets: FilterCutoff, FilterResonance, Osc1Pitch, Osc2Pitch, Osc2Detune, Osc2PWOffset, Osc1Vol, Osc2Vol, NoiseVol, RingModVol, NoiseColor, OscPitch (both), UnisonDetune, OscPW, OscCrossmod, LFO1Mod1/2, LFO2Rate, LFO2Mod1/2, FilterEnvAttack/Release, AmpEnvAttack/Release
- `recalculateMatrix` zeroes then reaccumulates adjustments from stored source values — called at every note-on/off and every MPE event; avoids per-sample accumulation drift
- `isLFO2Bound` cache: only runs per-sample recalculation when an LFO2 source row is active
- `VoiceMatrixAdjustments` / `VoiceMatrixRanges` — per-voice accumulators with documented natural-unit scaling (+/−1 source → native units)
- `VoiceMatrixSourceValues` — per-voice store of last received source values (−1..1)
- Thread-safe `MatrixUpdateFifo` (UI→audio) drained in `processBlock`
- XML streaming (`toElement` / `fromElement`) integrated into patch save/load

- `ProcessSample` receives `VoiceMatrix` and applies all adjustments at the correct signal-path point using save/restore to prevent per-sample accumulation
- Filter cutoff, resonance, osc pitches, osc PW, detune, crossmod, mixer volumes, noise colour, LFO mod amounts, LFO2 rate, envelope A/R times all modulated
- `applyMatrixAttack` / `applyMatrixRelease` added to `AdsrEnvelope` for per-voice envelope time modulation without disturbing the base parameter
- Base values (`lfo2BaseRate`, `filterEnvAttackBase`, etc.) tracked alongside engine setters so the matrix has a stable reference to offset from
- Velocity and ReleaseVelocity sources wired at NoteOn / NoteOff respectively

- `MPEMatrixEditor` — temporary stock-JUCE panel: enable toggle, pitch-bend-range spinner, per-row source / target / depth controls; not for production

- `mpeEnabled` and `mpePitchBendRange` saved/restored in DAWExtraState XML
- `VoiceMatrix` rows saved/restored per-patch in program XML

- 13 Layer-1 unit tests: VoiceMatrix recalculation, accumulation, validation, isLFO2Bound cache, XML round-trip, clear/fromElement(nullptr)
- 14 Layer-2 integration tests: channel isolation on NoteOff, MPE source normalisation, velocity/release-velocity storage, matrix adjustment computation, mpeBend reset on retrigger

- `MatrixPreset` block in VoiceMatrix.h is throwaway / for testing only — remove before merge
- LFO2 as a matrix source is provisional (wired for testing) — decide whether to keep and document or remove
- `MPEMatrixEditor` uses stock JUCE widgets and must be replaced with a skinned component before release
- Test and play this more with a linnstrument and so on

Addresses #97