### PR TITLE
Patch Mutator part 2: Implementation

### DIFF
--- a/src/PluginProcessor.cpp
+++ b/src/PluginProcessor.cpp
@@ -470,7 +470,9 @@ void ObxfAudioProcessor::initializeCallbacks()
 
 void ObxfAudioProcessor::mutatePatch()
 {
-    paramAlgos->mutate(mutateSections);
+    paramAlgos->mutate(activeProgram, mutateSections);
+
+    processActiveProgramChanged();
     sendChangeMessage();
 }
 

--- a/src/PluginProcessor.cpp
+++ b/src/PluginProcessor.cpp
@@ -442,6 +442,10 @@ void ObxfAudioProcessor::initializeUtilsCallbacks()
         return state->loadFromMemoryBlock(mb);
     };
 
+    utils->loadMemoryBlockOntoProgramCallback = [this](juce::MemoryBlock &mb, Program &program) {
+        return state->loadFromMemoryBlockOntoProgram(mb, program);
+    };
+
     utils->getProgramStateInformation = [this](juce::MemoryBlock &mb) {
         state->getProgramStateInformation(mb);
     };

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -289,7 +289,7 @@ bool Utils::loadPatch(const juce::File &fxpFile)
 
     if (loadMemoryBlockCallback)
     {
-        if (!loadMemoryBlockCallback(mb)) // todo make it respond to any program number
+        if (!loadMemoryBlockCallback(mb))
             return false;
     }
 

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -243,6 +243,7 @@ void Utils::setCurrentThemeLocation(const Utils::ThemeLocation &loc)
 void Utils::setGuiSize(const int gui_size)
 {
     this->gui_size = gui_size;
+
     config->setValue("gui_size", gui_size);
     config->setNeedsToBeSaved(true);
 }
@@ -261,6 +262,7 @@ void Utils::scanAndUpdateThemes()
         else
         {
             auto dir = getThemeFolderFor(t);
+
             for (const auto &entry :
                  juce::RangedDirectoryIterator(dir, false, "*", juce::File::findDirectories))
             {
@@ -273,6 +275,7 @@ void Utils::scanAndUpdateThemes()
 bool Utils::loadPatch(const PatchTreeNode::ptr_t &fxpFile)
 {
     auto res = loadPatch(fxpFile->file);
+
     if (res && hostUpdateCallback)
     {
         hostUpdateCallback(fxpFile->index);
@@ -285,18 +288,39 @@ bool Utils::loadPatch(const juce::File &fxpFile)
     juce::MemoryBlock mb;
 
     if (!fxpFile.loadFileAsData(mb))
+    {
         return false;
+    }
 
     if (loadMemoryBlockCallback)
     {
         if (!loadMemoryBlockCallback(mb))
+        {
             return false;
+        }
     }
 
     currentPatch = fxpFile.getFileName();
     currentPatchFile = fxpFile;
 
     return true;
+}
+
+bool Utils::loadPatch(const juce::File &fxpFile, Program &program)
+{
+    juce::MemoryBlock mb;
+
+    if (!fxpFile.loadFileAsData(mb))
+    {
+        return false;
+    }
+
+    if (loadMemoryBlockOntoProgramCallback)
+    {
+        return loadMemoryBlockOntoProgramCallback(mb, program);
+    }
+
+    return false;
 }
 
 bool Utils::serializePatchAsFXPOnto(juce::MemoryBlock &memoryBlock) const
@@ -341,12 +365,16 @@ bool Utils::savePatch(const juce::File &fxpFile)
     if (serializePatchAsFXPOnto(memoryBlock))
     {
         if (!fxpFile.getParentDirectory().createDirectory())
+        {
             return false;
+        }
+
         fxpFile.replaceWithData(memoryBlock.getData(), memoryBlock.getSize());
         currentPatch = fxpFile.getFileName();
         currentPatchFile = fxpFile;
 
         rescanPatchTree();
+
         return true;
     }
     return false;
@@ -355,7 +383,9 @@ bool Utils::savePatch(const juce::File &fxpFile)
 void Utils::initializePatch() const
 {
     if (resetPatchToDefault)
+    {
         resetPatchToDefault();
+    }
 
     if (hostUpdateCallback)
     {
@@ -365,10 +395,11 @@ void Utils::initializePatch() const
 
 void Utils::copyPatch()
 {
-    juce::MemoryBlock serializedData;
-    if (serializePatchAsFXPOnto(serializedData))
+    juce::MemoryBlock mb;
+
+    if (serializePatchAsFXPOnto(mb))
     {
-        juce::SystemClipboard::copyTextToClipboard(serializedData.toBase64Encoding());
+        juce::SystemClipboard::copyTextToClipboard(mb.toBase64Encoding());
     }
 }
 
@@ -376,19 +407,25 @@ void Utils::pastePatch()
 {
     if (loadMemoryBlockCallback)
     {
-        juce::MemoryBlock memoryBlock;
-        if (memoryBlock.fromBase64Encoding(juce::SystemClipboard::getTextFromClipboard()))
-            loadMemoryBlockCallback(memoryBlock);
+        juce::MemoryBlock mb;
+
+        if (mb.fromBase64Encoding(juce::SystemClipboard::getTextFromClipboard()))
+        {
+            loadMemoryBlockCallback(mb);
+        }
     }
 }
 
 bool Utils::isPatchInClipboard()
 {
-    juce::MemoryBlock memoryBlock;
-    if (!memoryBlock.fromBase64Encoding(juce::SystemClipboard::getTextFromClipboard()))
-        return false;
+    juce::MemoryBlock mb;
 
-    return isMemoryBlockAPatch(memoryBlock);
+    if (!mb.fromBase64Encoding(juce::SystemClipboard::getTextFromClipboard()))
+    {
+        return false;
+    }
+
+    return isMemoryBlockAPatch(mb);
 }
 
 bool Utils::isMemoryBlockAPatch(const juce::MemoryBlock &mb)
@@ -397,11 +434,16 @@ bool Utils::isMemoryBlockAPatch(const juce::MemoryBlock &mb)
     const size_t dataSize = mb.getSize();
 
     if (dataSize < 28)
+    {
         return false;
+    }
 
     if (const fxSet *const set = static_cast<const fxSet *>(data);
         (!compareMagic(set->chunkMagic, "CcnK")) || fxbSwap(set->version) > fxbVersionNum)
+    {
         return false;
+    }
+
     return true;
 }
 
@@ -415,6 +457,7 @@ void Utils::setMenuScaleMode(MenuScaleMode msm)
 {
     config->setValue("menu_scale_mode", static_cast<int>(msm));
 }
+
 Utils::MenuScaleMode Utils::getMenuScaleMode() const
 {
     auto def = MenuScaleMode::WITH_OS;

--- a/src/Utils.h
+++ b/src/Utils.h
@@ -28,6 +28,7 @@
 #include <fmt/core.h>
 #include "filesystem/import.h"
 
+#include "Program.h"
 #include "Constants.h"
 
 inline static float getPitch(float index) { return 440.f * expf(mult * index); };
@@ -240,6 +241,7 @@ class Utils final
     // Load save and init patch
     bool loadPatch(const PatchTreeNode::ptr_t &fxpFile);
     bool loadPatch(const juce::File &fxpFile);
+    bool loadPatch(const juce::File &fxpFile, Program &program);
     bool savePatch(const juce::File &fxpFile);
     void initializePatch() const;
 
@@ -251,6 +253,7 @@ class Utils final
     // callbacks
     std::function<void(int idx)> hostUpdateCallback;
     std::function<bool(juce::MemoryBlock &)> loadMemoryBlockCallback;
+    std::function<bool(juce::MemoryBlock &, Program &)> loadMemoryBlockOntoProgramCallback;
     std::function<void(juce::MemoryBlock &)> getProgramStateInformation;
     std::function<void(char *, int)> copyTruncatedProgramNameToFXPBuffer;
     std::function<void()> resetPatchToDefault;

--- a/src/parameter/ParameterAlgos.h
+++ b/src/parameter/ParameterAlgos.h
@@ -53,31 +53,46 @@ struct ParameterAlgos
     {
     }
 
-    void mutate(MutateMask what)
+    void mutate(Program &program, MutateMask what)
     {
         std::uniform_int_distribution<> distPL(0, utils.patchesAsLinearList.size() - 1);
-        const uint8_t sectionsToMutate = what.count();
         std::vector<int> indices;
-        std::array<Program, NUM_SECTIONS_TO_MUTATE> tempProg;
+        auto tempProg = Program();
 
-        // grab a patch index for each section we want to mutate
-        // make it non-repeating random picks
-        for (int i = 0; i < sectionsToMutate; i++)
+        for (int i = 0; i < NUM_SECTIONS_TO_MUTATE; i++)
         {
-            auto n = distPL(rng);
-
-            while (std::find(std::begin(indices), std::end(indices), n) != indices.end())
+            if (what.test(i))
             {
-                n = distPL(rng);
+                // grab a patch index for each section we want to mutate
+                // make it non-repeating random picks
+                auto n = distPL(rng);
+
+                while (std::find(std::begin(indices), std::end(indices), n) != indices.end())
+                {
+                    n = distPL(rng);
+                }
+
+                indices.push_back(n);
+
+                // load the patch
+                auto p = utils.patchesAsLinearList[n];
+                utils.loadPatch(p->file, tempProg);
+
+                // copy only parameters belonging to a particular mutate section (osc, filter, etc.)
+                for (auto &p : program.values)
+                {
+                    for (const auto &paramInfo : ParameterList)
+                    {
+                        if (paramInfo.ID.compare(p.first) == 0)
+                        {
+                            if (paramInfo.meta.hasFeature(mutateSectionList[i]))
+                            {
+                                p.second.store(tempProg.getValueById(p.first));
+                            }
+                        }
+                    }
+                }
             }
-
-            indices.push_back(n);
-
-            auto p = utils.patchesAsLinearList[n];
-
-            OBLOG(patches, "loaded patch index " << n << ", " << p->displayName.toStdString());
-
-            utils.loadPatch(p->file, tempProg[i]);
         }
     }
 

--- a/src/parameter/ParameterAlgos.h
+++ b/src/parameter/ParameterAlgos.h
@@ -58,6 +58,7 @@ struct ParameterAlgos
         std::uniform_int_distribution<> distPL(0, utils.patchesAsLinearList.size() - 1);
         const uint8_t sectionsToMutate = what.count();
         std::vector<int> indices;
+        std::array<Program, NUM_SECTIONS_TO_MUTATE> tempProg;
 
         // grab a patch index for each section we want to mutate
         // make it non-repeating random picks
@@ -71,9 +72,13 @@ struct ParameterAlgos
             }
 
             indices.push_back(n);
-        }
 
-        // TODO: execute loading programs and picking out data from them to mutate with
+            auto p = utils.patchesAsLinearList[n];
+
+            OBLOG(patches, "loaded patch index " << n << ", " << p->displayName.toStdString());
+
+            utils.loadPatch(p->file, tempProg[i]);
+        }
     }
 
     void randomizeToAlgo(RandomAlgos algo)

--- a/src/parameter/ParameterAlgos.h
+++ b/src/parameter/ParameterAlgos.h
@@ -44,6 +44,9 @@ enum PanAlgos
     SPREAD_100,
 };
 
+static std::array<ObxfParamFeatures, NUM_SECTIONS_TO_MUTATE> mutateSectionList{
+    IS_OSCS, IS_MIXER, IS_FILTER, IS_LFOS, IS_ENVS, IS_VOICE};
+
 struct ParameterAlgos
 {
     ParameterCoordinator &manager;

--- a/src/parameter/ParameterList.h
+++ b/src/parameter/ParameterList.h
@@ -44,6 +44,9 @@ enum ObxfParamFeatures : uint64_t
     IS_ENVS = IS_FEG + IS_AEG,
 };
 
+static std::array<ObxfParamFeatures, NUM_SECTIONS_TO_MUTATE> mutateSectionList{
+    IS_OSCS, IS_MIXER, IS_FILTER, IS_LFOS, IS_ENVS, IS_VOICE};
+
 inline pmd customPan()
 {
     // This basically sets up the pan knobs showing stuff like 37 L, 92 R and Center

--- a/src/parameter/ParameterList.h
+++ b/src/parameter/ParameterList.h
@@ -44,9 +44,6 @@ enum ObxfParamFeatures : uint64_t
     IS_ENVS = IS_FEG + IS_AEG,
 };
 
-static std::array<ObxfParamFeatures, NUM_SECTIONS_TO_MUTATE> mutateSectionList{
-    IS_OSCS, IS_MIXER, IS_FILTER, IS_LFOS, IS_ENVS, IS_VOICE};
-
 inline pmd customPan()
 {
     // This basically sets up the pan knobs showing stuff like 37 L, 92 R and Center

--- a/src/state/StateManager.cpp
+++ b/src/state/StateManager.cpp
@@ -84,6 +84,91 @@ void StateManager::getActiveProgramStateOnto(juce::XmlElement &xmlState) const
     xmlState.setAttribute(S("project"), prog.getProject());
 }
 
+bool StateManager::getChunkFromFxpData(const void *data, size_t dataSize, const void *&outChunkData,
+                                       int &outChunkSize)
+{
+    if (dataSize < 28)
+    {
+        return false;
+    }
+
+    const auto set = static_cast<const fxSet *>(data);
+
+    if ((!compareMagic(set->chunkMagic, "CcnK")) || fxbSwap(set->version) > fxbVersionNum)
+    {
+        return false;
+    }
+
+    if (compareMagic(set->fxMagic, "FPCh"))
+    {
+        const auto *const cset = static_cast<const fxProgramSet *>(data);
+        const size_t chunkSize = static_cast<size_t>(fxbSwap(cset->chunkSize));
+
+        if (chunkSize + sizeof(fxProgramSet) - 8 > dataSize)
+        {
+            return false;
+        }
+
+        outChunkData = cset->chunk;
+        outChunkSize = static_cast<int>(chunkSize);
+
+        return true;
+    }
+    else
+    {
+        OBLOG(state, "Support for format " << set->fxMagic << " not available");
+        return false;
+    }
+}
+
+void StateManager::populateProgramFromXml(Program &program, const juce::XmlElement &e,
+                                          uint64_t versionNumber)
+{
+    program.setToDefaultPatch();
+
+    const bool newFormat = e.hasAttribute("voiceCount");
+
+    for (auto *param : ObxfAudioProcessor::ObxfParams(*audioProcessor))
+    {
+        const auto &paramId = param->paramID;
+        float value = 0.0f;
+
+        if (e.hasAttribute(paramId))
+        {
+            value = static_cast<float>(e.getDoubleAttribute(paramId, program.values[paramId]));
+        }
+        else
+        {
+            value = program.values[paramId];
+        }
+
+        if (!newFormat && paramId == "POLYPHONY")
+        {
+            value *= 0.25f;
+        }
+
+        // Legacy version mapping
+        if (versionNumber < 0x2025'12'13)
+        {
+            if (paramId.compare(SynthParam::ID::UnisonVoices) == 0)
+            {
+                const auto oldVal = juce::jlimit(
+                    0, MAX_PANNINGS - 1, static_cast<int>(std::round(value * (MAX_PANNINGS - 1))));
+                value = static_cast<float>(oldVal) / static_cast<float>(MAX_VOICES - 1);
+            }
+        }
+
+        program.values[paramId] = value;
+    }
+
+    // Populate Metadata
+    program.setName(e.getStringAttribute("programName", "Init"));
+    program.setAuthor(e.getStringAttribute("author", ""));
+    program.setLicense(e.getStringAttribute("license", ""));
+    program.setCategory(e.getStringAttribute("category", ""));
+    program.setProject(e.getStringAttribute("project", ""));
+}
+
 void StateManager::setPluginStateInformation(const void *data, int sizeInBytes)
 {
     OBLOG(state, "setStateInformation");
@@ -132,53 +217,8 @@ void StateManager::setProgramStateInformation(const void *data, const int sizeIn
 void StateManager::setActiveProgramStateFrom(const juce::XmlElement &pnode, uint64_t versionNumber)
 {
     auto &program = audioProcessor->getActiveProgram();
-    program.setToDefaultPatch();
 
-    const bool newFormat = pnode.hasAttribute("voiceCount");
-
-    for (auto *param : ObxfAudioProcessor::ObxfParams(*audioProcessor))
-    {
-        const auto &paramId = param->paramID;
-        float value = 0.0f;
-
-        if (pnode.hasAttribute(paramId))
-            value = static_cast<float>(pnode.getDoubleAttribute(paramId, program.values[paramId]));
-        else
-            value = program.values[paramId];
-
-        if (!newFormat && paramId == "POLYPHONY")
-        {
-            value *= 0.25f;
-        }
-
-        // pre-1.0: Increased Unison Voices from 8 to 32
-        if (versionNumber < 0x2025'12'13)
-        {
-            if (paramId.compare(SynthParam::ID::UnisonVoices) == 0)
-            {
-                const auto oldVal = juce::jlimit(
-                    0, MAX_PANNINGS - 1, static_cast<int>(std::round(value * (MAX_PANNINGS - 1))));
-                value = static_cast<float>(oldVal) / static_cast<float>(MAX_VOICES - 1);
-            }
-        }
-
-        /*         for (const auto &paramInfo : ParameterList)
-                {
-                    if (paramInfo.ID == paramId)
-                    {
-                        OBLOG(general, "paramName=" << paramId << " | paramID=" << paramInfo.meta.id
-                                                    << " | isEnv=" <<
-                    }
-                } */
-
-        program.values[paramId] = value;
-    }
-
-    program.setName(pnode.getStringAttribute(S("programName"), S(INIT_PATCH_NAME)));
-    program.setAuthor(pnode.getStringAttribute(S("author"), S("")));
-    program.setLicense(pnode.getStringAttribute(S("license"), S("")));
-    program.setCategory(pnode.getStringAttribute(S("category"), S("")));
-    program.setProject(pnode.getStringAttribute(S("project"), S("")));
+    populateProgramFromXml(program, pnode, versionNumber);
 
     audioProcessor->getSynth().getMotherboard()->voiceMatrix.fromElement(
         pnode.getChildByName("VoiceMatrix"));
@@ -186,33 +226,41 @@ void StateManager::setActiveProgramStateFrom(const juce::XmlElement &pnode, uint
 
 bool StateManager::loadFromMemoryBlock(juce::MemoryBlock &mb)
 {
-    const void *const data = mb.getData();
-    const size_t dataSize = mb.getSize();
+    const void *data = nullptr;
+    int sizeInBytes = 0;
 
-    if (dataSize < 28)
-        return false;
-
-    const auto set = static_cast<const fxSet *>(data);
-
-    if ((!compareMagic(set->chunkMagic, "CcnK")) || fxbSwap(set->version) > fxbVersionNum)
-        return false;
-
-    if (compareMagic(set->fxMagic, "FPCh")) // patch memory chunk
+    if (!getChunkFromFxpData(mb.getData(), mb.getSize(), data, sizeInBytes))
     {
-        const auto *const cset = static_cast<const fxProgramSet *>(data);
-
-        if (static_cast<size_t>(fxbSwap(cset->chunkSize)) + sizeof(fxProgramSet) - 8 >
-            static_cast<size_t>(dataSize))
-            return false;
-        setProgramStateInformation(cset->chunk, fxbSwap(cset->chunkSize));
-    }
-    else
-    {
-        OBLOG(state, "Support for format " << set->fxMagic << " not available");
         return false;
     }
+
+    setProgramStateInformation(data, sizeInBytes);
 
     return true;
+}
+
+bool StateManager::loadFromMemoryBlockOntoProgram(juce::MemoryBlock &mb, Program &program)
+{
+    const void *data = nullptr;
+    int sizeInBytes = 0;
+
+    if (!getChunkFromFxpData(mb.getData(), mb.getSize(), data, sizeInBytes))
+    {
+        return false;
+    }
+
+    if (const std::unique_ptr<juce::XmlElement> e =
+            juce::AudioProcessor::getXmlFromBinary(data, sizeInBytes))
+    {
+        auto ver = e->getStringAttribute("ob-xf_version");
+        auto verNo = fromHumanReadableVersion(ver.toStdString());
+
+        populateProgramFromXml(program, *e, verNo);
+
+        return true;
+    }
+
+    return false;
 }
 
 void StateManager::collectDAWExtraStateFromInstance()

--- a/src/state/StateManager.h
+++ b/src/state/StateManager.h
@@ -43,6 +43,12 @@ class StateManager final
     StateManager &operator=(const StateManager &) = delete;
 
     bool loadFromMemoryBlock(juce::MemoryBlock &mb);
+    bool loadFromMemoryBlockOntoProgram(juce::MemoryBlock &mb, Program &program);
+
+    bool getChunkFromFxpData(const void *data, size_t dataSize, const void *&outChunkData,
+                             int &outChunkSize);
+    void populateProgramFromXml(Program &program, const juce::XmlElement &e,
+                                uint64_t versionNumber);
 
     // This is the API used at the plugin edge. It includes daw extra state and
     // embeds the program as a subordinate node of the docuemtn


### PR DESCRIPTION
Refactored FXP loading so that it can also load into an arbitrary Program object, not just active program.

Closes #628 