### PR TITLE
Clicking RAND uses mutation instead of randomization

### DIFF
--- a/src/PluginEditor.cpp
+++ b/src/PluginEditor.cpp
@@ -1662,7 +1662,7 @@ void ObxfAudioProcessorEditor::createComponentsFromXml(const juce::XmlElement *d
                 if (!safeThis)
                     return;
 
-                safeThis->randomizeCallback();
+                safeThis->mutateCallback();
             };
 
             randomizePatchButton->onRightClick([safeThis]() {
@@ -3439,13 +3439,14 @@ void ObxfAudioProcessorEditor::showMutatorMenu()
 
     auto custom = std::make_unique<MutatorMenu>(
         processor.mutateSections,
-        [this](const int index, bool value) { this->processor.mutateSections[index] = value; },
-        [this](const MutatorMenu &menu) { this->processor.mutatePatch(); });
+        [this](const int index, bool value) { this->processor.mutateSections[index] = value; });
 
     m.addCustomItem(1, std::move(custom));
 
     m.showMenuAsync(obxf::defaultPopupMenuOptions(this));
 }
+
+void ObxfAudioProcessorEditor::mutateCallback() { processor.mutatePatch(); }
 
 void ObxfAudioProcessorEditor::randomizeCallback()
 {

--- a/src/PluginEditor.h
+++ b/src/PluginEditor.h
@@ -182,6 +182,8 @@ class ObxfAudioProcessorEditor final : public juce::AudioProcessorEditor,
     void keyboardFocusMainMenu();
 
     void showMutatorMenu();
+
+    void mutateCallback();
     void randomizeCallback();
 
   public:

--- a/src/PluginProcessor.cpp
+++ b/src/PluginProcessor.cpp
@@ -49,6 +49,8 @@ ObxfAudioProcessor::ObxfAudioProcessor()
 
     isHostAutomatedChange = true;
 
+    mutateSections.set();
+
     if (juce::PluginHostType().isCubase() || juce::PluginHostType().isNuendo() ||
         juce::PluginHostType().isSteinberg())
     {

--- a/src/gui/MutatorMenu.h
+++ b/src/gui/MutatorMenu.h
@@ -43,14 +43,12 @@ class MutatorMenu : public juce::PopupMenu::CustomComponent
 
     static constexpr int mutateMenuID = 1234;
     static constexpr int mutateMenuWidth = 300;
-    static constexpr int mutateMenuHeight = 89;
+    static constexpr int mutateMenuHeight = 60;
 
     using maskChangedCb = std::function<void(int index, bool value)>;
-    using mutateCb = std::function<void(const MutatorMenu &)>;
 
-    MutatorMenu(MutateMask initialMask, maskChangedCb maskCallback, mutateCb mutateCallback)
-        : CustomComponent(false), onMaskChanged(std::move(maskCallback)),
-          onMutate(std::move(mutateCallback))
+    MutatorMenu(MutateMask initialMask, maskChangedCb maskCallback)
+        : CustomComponent(false), onMaskChanged(std::move(maskCallback))
     {
         auto setupToggle = [this](juce::ToggleButton &b, const juce::String &text,
                                   const bool initValue, const int index) {
@@ -99,84 +97,9 @@ class MutatorMenu : public juce::PopupMenu::CustomComponent
         height = mutateMenuHeight;
     }
 
-    void paint(juce::Graphics &g) override
-    {
-        const auto area = getLocalBounds().removeFromBottom(22);
-
-        // separator
-        g.setColour(findColour(juce::PopupMenu::textColourId).withAlpha(0.3f));
-        g.fillRect(area.getX() + 4, area.getY() - 6, area.getWidth() - 8, 1);
-
-        getLookAndFeel().drawPopupMenuItem(g, mutateClickArea, false, anySectionActive(),
-                                           isMouseOverMutate, false, false, "Mutate!", "", nullptr,
-                                           nullptr);
-    }
-
-    void mouseDown(const juce::MouseEvent &e) override
-    {
-        if (isMouseOverMutate && anySectionActive())
-        {
-            // Left click = close the menu after mutating
-            if (e.mods.isLeftButtonDown())
-            {
-                if (onMutate)
-                    onMutate(*this);
-
-                if (auto *modal = juce::Component::getCurrentlyModalComponent())
-                {
-                    modal->exitModalState(mutateMenuID);
-                }
-            }
-            // Right click = keep the menu open after mutating
-            else if (e.mods.isRightButtonDown())
-            {
-                if (onMutate)
-                    onMutate(*this);
-
-                isMutateRightClicked = true;
-                layoutHandler.setColour(juce::PopupMenu::highlightedTextColourId,
-                                        juce::Colours::red);
-                repaint();
-            }
-        }
-    }
-
-    void mouseUp(const juce::MouseEvent &e) override
-    {
-        if (isMouseOverMutate)
-        {
-            if (isMutateRightClicked)
-            {
-                layoutHandler.setColour(juce::PopupMenu::highlightedTextColourId,
-                                        juce::Colours::white);
-                isMutateRightClicked = false;
-                repaint();
-            }
-        }
-    }
-
-    void mouseMove(const juce::MouseEvent &e) override
-    {
-        const bool nowOver = mutateClickArea.contains(e.getPosition());
-
-        if (nowOver != isMouseOverMutate)
-        {
-            isMouseOverMutate = nowOver;
-            repaint();
-        }
-    }
-
-    void mouseExit(const juce::MouseEvent &e) override
-    {
-        isMouseOverMutate = false;
-        repaint();
-    }
-
     void resized() override
     {
         auto area = getLocalBounds();
-
-        mutateClickArea = area.removeFromBottom(22).expanded(2, 0);
 
         area.removeFromTop(2);
         area.removeFromLeft(12);
@@ -200,14 +123,9 @@ class MutatorMenu : public juce::PopupMenu::CustomComponent
 
   private:
     maskChangedCb onMaskChanged;
-    mutateCb onMutate;
 
     juce::ToggleButton oscButton, mixerButton, filterButton, lfoButton, envButton, voiceButton;
 
-    bool isMouseOverMutate = false;
-    bool isMutateRightClicked = false;
-
-    juce::Rectangle<int> mutateClickArea;
     MutatorLookAndFeel layoutHandler;
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(MutatorMenu)

--- a/src/parameter/ParameterList.h
+++ b/src/parameter/ParameterList.h
@@ -111,18 +111,18 @@ static const std::vector<ParameterInfo> ParameterList{
     {ID::Tune,      pmd().asFloat().withName(Name::Tune)     .withRange(-100.f, 100.f).withLinearScaleFormatting("cents").withDecimalPlaces(1).withID(5150)},
 
     // <-- GLOBAL -->
-    {ID::Polyphony, pmd().asInt().withLinearScaleFormatting("Voices").withName(Name::Polyphony).withRange(1, MAX_VOICES).withDefault(8).withID(8675309)},
+    {ID::Polyphony, pmd().asInt().withLinearScaleFormatting("Voices").withName(Name::Polyphony).withRange(1, MAX_VOICES).withDefault(8).withFeature((uint64_t)IS_VOICE).withID(8675309)},
     {ID::HQMode,    pmd().asOnOffBool().withName(Name::HQMode).withID(90210)},
 
     {ID::UnisonVoices, pmd().asInt().withLinearScaleFormatting("Voices").withName(Name::UnisonVoices).withRange(1, MAX_VOICES).withDefault(8).withID(0101101)},
 
     {ID::Portamento,   pmd().asFloat().withName(Name::Portamento).withRange(0.f, 1.f).asPercent().withDecimalPlaces(1).withFeature((uint64_t)IS_VOICE).withID(1979)},
-    {ID::Unison,       pmd().asOnOffBool().withName(Name::Unison).withID(8)},
+    {ID::Unison,       pmd().asOnOffBool().withName(Name::Unison).withFeature((uint64_t)IS_VOICE).withID(8)},
     {ID::UnisonDetune, pmd().asFloat().withName(Name::UnisonDetune).withRange(0.f, 1.f).asPercent().withDefault(0.25f).withDecimalPlaces(1).withID(9846).withFeature((uint64_t)IS_VOICE)},
 
-    {ID::EnvLegatoMode, pmd().asInt().withName(Name::EnvLegatoMode).withRange(0, 3).withID(12340)
+    {ID::EnvLegatoMode, pmd().asInt().withName(Name::EnvLegatoMode).withFeature((uint64_t)IS_VOICE).withRange(0, 3).withID(12340)
                              .withUnorderedMapFormatting({{0, "Both"}, {1, "Filter"}, {2, "Amp"}, {3, "Retrigger"}})},
-    {ID::NotePriority,  pmd().asInt().withName(Name::NotePriority).withRange(0, 2).withID(153251)
+    {ID::NotePriority,  pmd().asInt().withName(Name::NotePriority).withFeature((uint64_t)IS_VOICE).withRange(0, 2).withID(153251)
                              .withUnorderedMapFormatting({{0, "Last"}, {1, "Low"}, {2, "High"}})},
 
     // <-- OSCILLATORS -->
@@ -165,7 +165,7 @@ static const std::vector<ParameterInfo> ParameterList{
     // <-- CONTROL -->
     {ID::BendUpRange,   pmd().asInt().withName(Name::BendUpRange).withRange(0, MAX_BEND_RANGE).withDefault(2).withID(3121235).withLinearScaleFormatting("Semitones")},
     {ID::BendDownRange, pmd().asInt().withName(Name::BendDownRange).withRange(0, MAX_BEND_RANGE).withDefault(2).withID(9800936).withLinearScaleFormatting("Semitones")},
-    {ID::BendOsc2Only,  pmd().asOnOffBool().withName(Name::BendOsc2Only).withID(979737)},
+    {ID::BendOsc2Only,  pmd().asOnOffBool().withName(Name::BendOsc2Only).withFeature((uint64_t)IS_OSCS).withID(979737)},
 
     {ID::VibratoWave,   pmd().asBool().withName(Name::VibratoWave).withFeature((uint64_t)IS_LFOS).withID(938).withUnorderedMapFormatting({{0, "Sine"}, {1, "Square"}})},
     {ID::VibratoRate,   pmd().asFloat().withName(Name::VibratoRate).withRange(0.f, 1.f)


### PR DESCRIPTION
After attempting to implement #367, I empirically found out that it's still producing not super useful patches a lot of the time, which is the opposite of expected. Mutation, on the other hand, majority of time produces really useful patches. So, behind the scenes, we will do mutation moving forward. Right click on RAND button retains the checkboxes for segmenting the mutation, but all of these are on by default now.

I left the randomizer code in even if I felt really tempted to completely remove it.