### PR TITLE
OB-Xd import: compensate pitch further

### DIFF
--- a/assets/binary/VectorTheme/theme.xml
+++ b/assets/binary/VectorTheme/theme.xml
@@ -279,12 +279,12 @@ However, if you omit the "pic" argument everywhere, the theme will still work be
     <widget name="select16Button"             x="1073" y="504" w="23"  h="35"                                           /> <!-- pic="button-group-patch" -->
 
     <!-- SAVE PATCH DIALOG                                                                                             -->
-    <widget name="savePatchDialog"                             w="246" h="328"                pic="label-bg-save-patch" />
-    <widget name="savePatchNameLabel"         x="22"   y="29"  w="200" h="31"                 color="FFFF0000"          /> <!-- color is AARRGGBB -->
-    <widget name="savePatchAuthorLabel"       x="22"   y="90"  w="200" h="31"                 color="FFFF0000"          /> <!-- color is AARRGGBB -->
-    <widget name="savePatchProjectLabel"      x="22"   y="151" w="200" h="31"                 color="FFFF0000"          /> <!-- color is AARRGGBB -->
-    <widget name="savePatchCategoryMenu"      x="25"   y="212" w="90"  h="31"                                           />
-    <widget name="savePatchLicenseLabel"      x="126"  y="212" w="96"  h="31"                 color="FFFF0000"          /> <!-- color is AARRGGBB -->
-    <widget name="savePatchOKButton"          x="92"   y="272" w="23"  h="35"                                           />
-    <widget name="savePatchCancelButton"      x="129"  y="272" w="23"  h="35"                                           />
+    <widget name="savePatchDialog"                             w="246" h="328"                                          /> <!-- pic="label-bg-save-patch" -->
+    <widget name="savePatchNameLabel"         x="22"   y="29"  w="200" h="31"                 color="FFFF0000"          /> <!-- color is AARRGGBB         -->
+    <widget name="savePatchAuthorLabel"       x="22"   y="90"  w="200" h="31"                 color="FFFF0000"          /> <!-- color is AARRGGBB         -->
+    <widget name="savePatchProjectLabel"      x="22"   y="151" w="200" h="31"                 color="FFFF0000"          /> <!-- color is AARRGGBB         -->
+    <widget name="savePatchCategoryMenu"      x="25"   y="212" w="90"  h="31"                                           /> <!-- pic="menu-categories"     -->
+    <widget name="savePatchLicenseLabel"      x="126"  y="212" w="96"  h="31"                 color="FFFF0000"          /> <!-- color is AARRGGBB         -->
+    <widget name="savePatchOKButton"          x="92"   y="272" w="23"  h="35"                                           /> <!-- pic="button-clear-red"    -->
+    <widget name="savePatchCancelButton"      x="129"  y="272" w="23"  h="35"                                           /> <!-- pic="button-clear-white"  -->
 </obxf-theme>

--- a/assets/installer/Surge Synth Team/OB-Xf/Themes/Default/theme.xml
+++ b/assets/installer/Surge Synth Team/OB-Xf/Themes/Default/theme.xml
@@ -279,12 +279,12 @@ However, if you omit the "pic" argument everywhere, the theme will still work be
     <widget name="select16Button"             x="1073" y="504" w="23"  h="35"                                           /> <!-- pic="button-group-patch" -->
 
     <!-- SAVE PATCH DIALOG                                                                                             -->
-    <widget name="savePatchDialog"                             w="246" h="328"                pic="label-bg-save-patch" />
-    <widget name="savePatchNameLabel"         x="22"   y="29"  w="200" h="31"                 color="FFFF0000"          /> <!-- color is AARRGGBB -->
-    <widget name="savePatchAuthorLabel"       x="22"   y="90"  w="200" h="31"                 color="FFFF0000"          /> <!-- color is AARRGGBB -->
-    <widget name="savePatchProjectLabel"      x="22"   y="151" w="200" h="31"                 color="FFFF0000"          /> <!-- color is AARRGGBB -->
-    <widget name="savePatchCategoryMenu"      x="25"   y="212" w="90"  h="31"                                           />
-    <widget name="savePatchLicenseLabel"      x="126"  y="212" w="96"  h="31"                 color="FFFF0000"          /> <!-- color is AARRGGBB -->
-    <widget name="savePatchOKButton"          x="92"   y="272" w="23"  h="35"                                           />
-    <widget name="savePatchCancelButton"      x="129"  y="272" w="23"  h="35"                                           />
+    <widget name="savePatchDialog"                             w="246" h="328"                                          /> <!-- pic="label-bg-save-patch" -->
+    <widget name="savePatchNameLabel"         x="22"   y="29"  w="200" h="31"                 color="FFFF0000"          /> <!-- color is AARRGGBB         -->
+    <widget name="savePatchAuthorLabel"       x="22"   y="90"  w="200" h="31"                 color="FFFF0000"          /> <!-- color is AARRGGBB         -->
+    <widget name="savePatchProjectLabel"      x="22"   y="151" w="200" h="31"                 color="FFFF0000"          /> <!-- color is AARRGGBB         -->
+    <widget name="savePatchCategoryMenu"      x="25"   y="212" w="90"  h="31"                                           /> <!-- pic="menu-categories"     -->
+    <widget name="savePatchLicenseLabel"      x="126"  y="212" w="96"  h="31"                 color="FFFF0000"          /> <!-- color is AARRGGBB         -->
+    <widget name="savePatchOKButton"          x="92"   y="272" w="23"  h="35"                                           /> <!-- pic="button-clear-red"    -->
+    <widget name="savePatchCancelButton"      x="129"  y="272" w="23"  h="35"                                           /> <!-- pic="button-clear-white"  -->
 </obxf-theme>

--- a/src/Utils.h
+++ b/src/Utils.h
@@ -31,7 +31,7 @@
 #include "Program.h"
 #include "Constants.h"
 
-inline static float getPitch(float index) { return 440.f * expf(mult * index); };
+inline static float getPitch(float index) { return 440.f * std::exp(mult * index); };
 
 inline static float linsc(float param, const float min, const float max)
 {
@@ -40,7 +40,7 @@ inline static float linsc(float param, const float min, const float max)
 
 inline static float logsc(float param, const float min, const float max, const float rolloff = 19.f)
 {
-    return ((expf(param * logf(rolloff + 1.f)) - 1.f) / (rolloff)) * (max - min) + min;
+    return ((std::exp(param * std::log(rolloff + 1.f)) - 1.f) / (rolloff)) * (max - min) + min;
 }
 
 inline std::string humanReadableVersion(const uint64_t v)
@@ -279,7 +279,6 @@ class Utils final
 
     LocationType resolvedFactoryLocationType{SYSTEM_FACTORY};
 
-    void updateConfig();
     bool serializePatchAsFXPOnto(juce::MemoryBlock &memoryBlock) const;
     bool isMemoryBlockAPatch(const juce::MemoryBlock &mb);
 

--- a/src/state/ObxdImporter.cpp
+++ b/src/state/ObxdImporter.cpp
@@ -126,8 +126,8 @@ enum ObxdParam : int
 };
 
 // Re-implementations of OB-Xd's logsc/linsc plus their inverses, used for
-// rescaling normalized values across the two engines. Matches the OB-Xd
-// definitions in Source/Engine/AudioUtils.h.
+// rescaling normalized values across the two engines.
+// Matches the OB-Xd definitions in Source/Engine/AudioUtils.h.
 inline float xdLogsc(float p, float lo, float hi, float rolloff = 19.f)
 {
     return ((std::exp(p * std::log(rolloff + 1.f)) - 1.f) / rolloff) * (hi - lo) + lo;
@@ -247,15 +247,14 @@ void ObxdImporter::translateProgramFromXml(const juce::XmlElement &e, Program &p
 
     // ---- Master ----
 
-    const auto transpose = std::clamp((int)(std::round(val(OCTAVE) * 4.f) + 1), 0, 4) * 0.25f;
+    const auto transpose = static_cast<int>(std::round(val(OCTAVE) * 4.f) + 1);
 
     program.values[ID::Volume] = val(VOLUME);
     program.values[ID::Tune] = val(TUNE);
-    program.values[ID::Transpose] = transpose;
+    program.values[ID::Transpose] = std::clamp(transpose, 0, 4) * 0.25f;
 
     warnings.emplace_back("OCTAVE: OB-Xd had the middle C frequency reference an octave too high; "
-                          "OB-Xf compensates for this, but patches which already had Coarse knob "
-                          "set to maximum will sound an octave lower.");
+                          "OB-Xf compensates for this by adjusting the Transpose parameter.");
 
     // ---- Global ----
 
@@ -310,8 +309,23 @@ void ObxdImporter::translateProgramFromXml(const juce::XmlElement &e, Program &p
 
     // ---- Oscillators ----
 
-    const auto osc1Pitch = oscStep ? ((int)(val(OSC1P) * 48.f)) / 48.f : val(OSC1P);
-    const auto osc2Pitch = oscStep ? ((int)(val(OSC1P) * 48.f)) / 48.f : val(OSC2P);
+    auto osc1PitchRaw = val(OSC1P) * 48.f;
+    auto osc2PitchRaw = val(OSC2P) * 48.f;
+
+    if (osc1PitchRaw <= 36.f && osc2PitchRaw <= 36.f && transpose > 4.f)
+    {
+        osc1PitchRaw = osc1PitchRaw + 12.f;
+        osc2PitchRaw = osc2PitchRaw + 12.f;
+
+        warnings.emplace_back(
+            "OCTAVE: The imported sound has already had the Transpose parameter set to maximum "
+            "value."
+            "OB-Xf compensates for this by adjusting the Osc 1 and Osc 2 Pitch parameters an "
+            "octave upwards.");
+    }
+
+    const auto osc1Pitch = oscStep ? ((int)(osc1PitchRaw)) / 48.f : osc1PitchRaw / 48.f;
+    const auto osc2Pitch = oscStep ? ((int)(osc2PitchRaw)) / 48.f : osc2PitchRaw / 48.f;
 
     program.values[ID::Osc1Pitch] = osc1Pitch;
     program.values[ID::Osc2Pitch] = osc2Pitch;


### PR DESCRIPTION
If after compensating with Transpose parameter we are short an octave still, see if we can raise the pitches of both oscillators up by the required amount.

Also, minor consistency update for theme.xml files.