### PR TITLE
Implement generic panel groups

### DIFF
--- a/assets/binary/VectorTheme/theme.xml
+++ b/assets/binary/VectorTheme/theme.xml
@@ -25,268 +25,268 @@ However, if you omit the "pic" argument everywhere, the theme will still work be
 -->
 
 <obxf-theme>
-    <widget name="aboutPage"                  x="30"   y="14"  w="220" h="74"                                           /> <!-- only acts as a click area! -->
+    <widget name="aboutPage"                  x="30"   y="14"  w="220" h="74"                                               /> <!-- only acts as a click area! -->
 
-    <!-- MASTER                                                                                                        -->
-    <widget name="masterBGLabel"              x="31"   y="102"  w="218" h="84"                pic="label-bg-master"     />
-    <widget name="volumeKnob"                 x="52"   y="127"                 d="40"         pic="knob"                />
-    <widget name="transposeKnob"              x="120"  y="127"                 d="40"         pic="knob"                />
-    <widget name="tuneKnob"                   x="188"  y="127"                 d="40"         pic="knob"                />
+    <!-- MASTER                                                                                                            -->
+    <widget name="masterBGLabel"              x="31"   y="102"  w="218" h="84"                pic="label-bg-master"         />
+    <widget name="volumeKnob"                 x="52"   y="127"                 d="40"         pic="knob"                    />
+    <widget name="transposeKnob"              x="120"  y="127"                 d="40"         pic="knob"                    />
+    <widget name="tuneKnob"                   x="188"  y="127"                 d="40"         pic="knob"                    />
 
-    <!-- GLOBAL                                                                                                        -->
-    <widget name="globalBGLabel"              x="31"   y="201" w="218" h="268"                pic="label-bg-global"     />
-    <!-- <widget name="mpeLinesLabel"              x="37"   y="258" w="118" h="114"                pic="label-mpe-lines"     /> -->
-    <widget name="polyphonyMenu"              x="56"   y="235" w="31"  h="31"                                           /> <!-- pic="menu-poly" -->
-    <widget name="hqModeButton"               x="128"  y="233" w="23"  h="35"                 pic="button"              />
-    <widget name="lockHQButton"               x="154"  y="272" w="11"  h="11"                 pic="button-lock"         />
-    <widget name="unisonVoicesMenu"           x="192"  y="235" w="31"  h="31"                                           /> <!-- pic="menu-poly" -->
+    <!-- GLOBAL                                                                                                            -->
+    <widget name="globalBGLabel"              x="31"   y="201" w="218" h="268"                pic="label-bg-global"         />
+    <!-- <widget name="mpeLinesLabel"              x="37"   y="258" w="118" h="114"                pic="label-mpe-lines"         /> -->
+    <widget name="polyphonyMenu"              x="56"   y="235" w="31"  h="31"                                               /> <!-- pic="menu-poly" -->
+    <widget name="hqModeButton"               x="128"  y="233" w="23"  h="35"                 pic="button"                  />
+    <widget name="lockHQButton"               x="154"  y="272" w="11"  h="11"                 pic="button-lock"             />
+    <widget name="unisonVoicesMenu"           x="192"  y="235" w="31"  h="31"                                               /> <!-- pic="menu-poly" -->
 
-    <widget name="portamentoKnob"             x="52"   y="291"                 d="40"         pic="knob"                />
-    <widget name="unisonButton"               x="128"  y="293" w="23"  h="35"                 pic="button"              />
-    <widget name="unisonDetuneKnob"           x="188"  y="291"                 d="40"         pic="knob"                />
+    <widget name="portamentoKnob"             x="52"   y="291"                 d="40"         pic="knob"                    />
+    <widget name="unisonButton"               x="128"  y="293" w="23"  h="35"                 pic="button"                  />
+    <widget name="unisonDetuneKnob"           x="188"  y="291"                 d="40"         pic="knob"                    />
 
-    <widget name="envLegatoModeMenu"          x="56"   y="357" w="90"  h="31"                                           /> <!-- pic="menu-legato"        -->
-    <widget name="notePriorityMenu"           x="161"  y="357" w="64"  h="31"                                           /> <!-- pic="menu-note-priority" -->
+    <widget name="envLegatoModeMenu"          x="56"   y="357" w="90"  h="31"                                               /> <!-- pic="menu-legato"        -->
+    <widget name="notePriorityMenu"           x="161"  y="357" w="64"  h="31"                                               /> <!-- pic="menu-note-priority" -->
 
-    <widget name="mainMenu"                   x="60"   y="415" w="23"  h="35"                 pic="button-clear-red"    />
-    <widget name="mpeButton"                  x="128"  y="415" w="23"  h="35"                 pic="button"              />
-    <widget name="midiLearnButton"            x="196"  y="415" w="23"  h="35"                 pic="button"              />
+    <widget name="mainMenu"                   x="60"   y="415" w="23"  h="35"                 pic="button-clear-red"        />
+    <widget name="mpeButton"                  x="128"  y="415" w="23"  h="35"                 pic="button"                  />
+    <widget name="midiLearnButton"            x="196"  y="415" w="23"  h="35"                 pic="button"                  />
 
-    <!-- OSCILLATORS                                                                                                   -->
-    <widget name="osc1PitchKnob"              x="287"  y="48"                  d="40"         pic="knob"                />
-    <widget name="osc2DetuneKnob"             x="354"  y="48"                  d="40"         pic="knob"                />
-    <widget name="osc2PitchKnob"              x="422"  y="48"                  d="40"         pic="knob"                />
-    <widget name="osc2KeytrackButton"         x="463"  y="91"  w="11"  h="11"                 pic="button-keytrack"     />
+    <!-- OSCILLATORS                                                                                                       -->
+    <widget name="osc1PitchKnob"              x="287"  y="48"                  d="40"         pic="knob"                    />
+    <widget name="osc2DetuneKnob"             x="354"  y="48"                  d="40"         pic="knob"                    />
+    <widget name="osc2PitchKnob"              x="422"  y="48"                  d="40"         pic="knob"                    />
+    <widget name="osc2KeytrackButton"         x="463"  y="91"  w="11"  h="11"                 pic="button-keytrack"         />
 
-    <widget name="osc1SawButton"              x="277"  y="129" w="23"  h="35"                 pic="button"              />
-    <widget name="osc1PulseButton"            x="314"  y="129" w="23"  h="35"                 pic="button"              />
+    <widget name="osc1SawButton"              x="277"  y="129" w="23"  h="35"                 pic="button"                  />
+    <widget name="osc1PulseButton"            x="314"  y="129" w="23"  h="35"                 pic="button"                  />
 
-    <widget name="osc1TriangleLabel"          x="299"  y="170" w="16"  h="10"                 pic="label-osc-triangle"  />
-    <widget name="osc1PulseLabel"             x="319"  y="171" w="14"  h="8"                  pic="label-osc-pulse"     />
+    <widget name="osc1TriangleLabel"          x="299"  y="170" w="16"  h="10"                 pic="label-osc-triangle"      />
+    <widget name="osc1PulseLabel"             x="319"  y="171" w="14"  h="8"                  pic="label-osc-pulse"         />
 
-    <widget name="osc2SawButton"              x="412"  y="129" w="23"  h="35"                 pic="button"              />
-    <widget name="osc2PulseButton"            x="449"  y="129" w="23"  h="35"                 pic="button"              />
+    <widget name="osc2SawButton"              x="412"  y="129" w="23"  h="35"                 pic="button"                  />
+    <widget name="osc2PulseButton"            x="449"  y="129" w="23"  h="35"                 pic="button"                  />
 
-    <widget name="osc2TriangleLabel"          x="434"  y="170" w="16"  h="10"                 pic="label-osc-triangle"  />
-    <widget name="osc2PulseLabel"             x="454"  y="171" w="14"  h="8"                  pic="label-osc-pulse"     />
+    <widget name="osc2TriangleLabel"          x="434"  y="170" w="16"  h="10"                 pic="label-osc-triangle"      />
+    <widget name="osc2PulseLabel"             x="454"  y="171" w="14"  h="8"                  pic="label-osc-pulse"         />
 
-    <widget name="oscPWKnob"                  x="354"  y="127"                 d="40"         pic="knob"                />
-    <widget name="osc2PWOffsetKnob"           x="354"  y="218"                 d="40"         pic="knob"                />
+    <widget name="oscPWKnob"                  x="354"  y="127"                 d="40"         pic="knob"                    />
+    <widget name="osc2PWOffsetKnob"           x="354"  y="218"                 d="40"         pic="knob"                    />
 
-    <widget name="envToPitchAmountKnob"       x="287"  y="218"                 d="40"         pic="knob"                />
-    <widget name="envToPitchBothOscsButton"   x="279"  y="187" w="18"  h="13"                 pic="button-slim"         />
-    <widget name="envToPitchInvertButton"     x="316"  y="187" w="18"  h="13"                 pic="button-slim"         />
+    <widget name="envToPitchAmountKnob"       x="287"  y="218"                 d="40"         pic="knob"                    />
+    <widget name="envToPitchBothOscsButton"   x="279"  y="187" w="18"  h="13"                 pic="button-slim"             />
+    <widget name="envToPitchInvertButton"     x="316"  y="187" w="18"  h="13"                 pic="button-slim"             />
 
-    <widget name="envToPWAmountKnob"          x="422"  y="218"                 d="40"         pic="knob"                />
-    <widget name="envToPWBothOscsButton"      x="452"  y="187" w="18"  h="13"                 pic="button-slim"         />
-    <widget name="envToPWInvertButton"        x="415"  y="187" w="18"  h="13"                 pic="button-slim"         />
+    <widget name="envToPWAmountKnob"          x="422"  y="218"                 d="40"         pic="knob"                    />
+    <widget name="envToPWBothOscsButton"      x="452"  y="187" w="18"  h="13"                 pic="button-slim"             />
+    <widget name="envToPWInvertButton"        x="415"  y="187" w="18"  h="13"                 pic="button-slim"             />
 
-    <widget name="oscCrossmodKnob"            x="287"  y="291"                 d="40"         pic="knob"                />
-    <widget name="oscSyncButton"              x="363"  y="293" w="23"  h="35"                 pic="button"              />
-    <widget name="oscBrightnessKnob"          x="422"  y="291"                 d="40"         pic="knob"                />
+    <widget name="oscCrossmodKnob"            x="287"  y="291"                 d="40"         pic="knob"                    />
+    <widget name="oscSyncButton"              x="363"  y="293" w="23"  h="35"                 pic="button"                  />
+    <widget name="oscBrightnessKnob"          x="422"  y="291"                 d="40"         pic="knob"                    />
 
-    <!-- MIXER                                                                                                         -->
-    <widget name="osc1VolKnob"                x="520"  y="48"                  d="40"         pic="knob"                />
-    <widget name="osc2VolKnob"                x="520"  y="127"                 d="40"         pic="knob"                />
-    <widget name="ringModVolKnob"             x="520"  y="218"                 d="40"         pic="knob"                />
-    <widget name="noiseVolKnob"               x="520"  y="291"                 d="40"         pic="knob"                />
-    <widget name="noiseColorButton"           x="504"  y="333" w="18"  h="13"                 pic="button-slim-noise"   />
+    <!-- MIXER                                                                                                             -->
+    <widget name="osc1VolKnob"                x="520"  y="48"                  d="40"         pic="knob"                    />
+    <widget name="osc2VolKnob"                x="520"  y="127"                 d="40"         pic="knob"                    />
+    <widget name="ringModVolKnob"             x="520"  y="218"                 d="40"         pic="knob"                    />
+    <widget name="noiseVolKnob"               x="520"  y="291"                 d="40"         pic="knob"                    />
+    <widget name="noiseColorButton"           x="504"  y="333" w="18"  h="13"                 pic="button-slim-noise"       />
 
-    <!-- CONTROL                                                                                                       -->
-    <widget name="bendDownRangeMenu"          x="291"  y="417" w="31"  h="31"                                           /> <!-- pic="menu-pitch-bend" -->
-    <widget name="bendUpRangeMenu"            x="359"  y="417" w="31"  h="31"                                           /> <!-- pic="menu-pitch-bend" -->
-    <widget name="bendOsc2OnlyButton"         x="431"  y="415" w="23"  h="35"                 pic="button"              />
-    <widget name="lockBendRangeButton"        x="335"  y="427" w="11"  h="11"                 pic="button-lock"         />
+    <!-- CONTROL                                                                                                           -->
+    <widget name="bendDownRangeMenu"          x="291"  y="417" w="31"  h="31"                                               /> <!-- pic="menu-pitch-bend" -->
+    <widget name="bendUpRangeMenu"            x="359"  y="417" w="31"  h="31"                                               /> <!-- pic="menu-pitch-bend" -->
+    <widget name="bendOsc2OnlyButton"         x="431"  y="415" w="23"  h="35"                 pic="button"                  />
+    <widget name="lockBendRangeButton"        x="335"  y="427" w="11"  h="11"                 pic="button-lock"             />
 
-    <widget name="vibratoWaveButton"          x="491"  y="426" w="18"  h="13"                 pic="button-slim"         />
-    <widget name="vibratoRateKnob"            x="520"  y="413"                 d="40"         pic="knob"                />
+    <widget name="vibratoWaveButton"          x="491"  y="426" w="18"  h="13"                 pic="button-slim-vibrato-wave"/>
+    <widget name="vibratoRateKnob"            x="520"  y="413"                 d="40"         pic="knob"                    />
 
-    <!-- FILTER                                                                                                        -->
-    <widget name="filter4PoleModeButton"      x="601"  y="20"  w="18"  h="13"                 pic="button-slim"         />
+    <!-- FILTER                                                                                                            -->
+    <widget name="filter4PoleModeButton"      x="601"  y="20"  w="18"  h="13"                 pic="button-slim"             />
 
-    <widget name="filterCutoffKnob"           x="616"  y="48"                  d="40"         pic="knob"                />
-    <widget name="filterResonanceKnob"        x="684"  y="48"                  d="40"         pic="knob"                />
-    <widget name="filterEnvAmountKnob"        x="752"  y="48"                  d="40"         pic="knob"                />
+    <widget name="filterCutoffKnob"           x="616"  y="48"                  d="40"         pic="knob"                    />
+    <widget name="filterResonanceKnob"        x="684"  y="48"                  d="40"         pic="knob"                    />
+    <widget name="filterEnvAmountKnob"        x="752"  y="48"                  d="40"         pic="knob"                    />
 
-    <widget name="filterKeyTrackKnob"         x="616"  y="127"                 d="40"         pic="knob"                />
-    <widget name="filterModeKnob"             x="684"  y="127"                 d="40"         pic="knob"                />
+    <widget name="filterKeyTrackKnob"         x="616"  y="127"                 d="40"         pic="knob"                    />
+    <widget name="filterModeKnob"             x="684"  y="127"                 d="40"         pic="knob"                    />
 
-    <widget name="filter2PoleBPBlendButton"   x="749"  y="131" w="18"  h="13"                 pic="button-slim"         />
-    <widget name="filter2PolePushButton"      x="749"  y="151" w="18"  h="13"                 pic="button-slim"         />
+    <widget name="filter2PoleBPBlendButton"   x="749"  y="131" w="18"  h="13"                 pic="button-slim"             />
+    <widget name="filter2PolePushButton"      x="749"  y="151" w="18"  h="13"                 pic="button-slim"             />
 
-    <widget name="filter4PoleXpanderButton"   x="760"  y="129" w="23"  h="35"                 pic="button"              />
-    <widget name="filterXpanderModeMenu"      x="674"  y="132" w="62"  h="31"                                           /> <!-- pic="menu-xpander"         -->
+    <widget name="filter4PoleXpanderButton"   x="760"  y="129" w="23"  h="35"                 pic="button"                  />
+    <widget name="filterXpanderModeMenu"      x="674"  y="132" w="62"  h="31"                                               /> <!-- pic="menu-xpander"         -->
 
-    <widget name="filterModeLabel"            x="670"  y="116" w="70"  h="56"                                           /> <!-- pic="label-filter-mode"    -->
-    <widget name="filterOptionsLabel"         x="747"  y="127" w="54"  h="54"                                           /> <!-- pic="label-filter-options" -->
+    <widget name="filterModeLabel"            x="670"  y="116" w="70"  h="56"                                               /> <!-- pic="label-filter-mode"    -->
+    <widget name="filterOptionsLabel"         x="747"  y="127" w="54"  h="54"                                               /> <!-- pic="label-filter-options" -->
 
-    <!-- LFOS                                                                                                          -->
-    <widget name="lfo1SelectButton"           x="757"  y="213" w="18"  h="13"                 pic="button-slim"         />
-    <widget name="lfo2SelectButton"           x="789"  y="213" w="18"  h="13"                 pic="button-slim-alt"     />
+    <!-- LFOS                                                                                                              -->
+    <widget name="lfo1SelectButton"           x="757"  y="213" w="18"  h="13"                 pic="button-slim"             />
+    <widget name="lfo2SelectButton"           x="789"  y="213" w="18"  h="13"                 pic="button-slim-alt"         />
 
-    <!-- LFO 1                                                                                                         -->
-    <widget name="lfo1TempoSyncButton"        x="601"  y="213" w="18"  h="13"                 pic="button-slim"         />
+    <!-- LFO 1                                                                                                             -->
+    <widget name="lfo1TempoSyncButton"        x="601"  y="213" w="18"  h="13"                 pic="button-slim"             />
 
-    <widget name="lfo1RateKnob"               x="616"  y="233"                 d="40"         pic="knob"                />
-    <widget name="lfo1ModAmount1Knob"         x="684"  y="233"                 d="40"         pic="knob"                />
-    <widget name="lfo1ModAmount2Knob"         x="752"  y="233"                 d="40"         pic="knob"                />
+    <widget name="lfo1RateKnob"               x="616"  y="233"                 d="40"         pic="knob"                    />
+    <widget name="lfo1ModAmount1Knob"         x="684"  y="233"                 d="40"         pic="knob"                    />
+    <widget name="lfo1ModAmount2Knob"         x="752"  y="233"                 d="40"         pic="knob"                    />
 
-    <widget name="lfo1Wave1Knob"              x="616"  y="291"                 d="40"         pic="knob"                />
-    <widget name="lfo1Wave2Knob"              x="616"  y="353"                 d="40"         pic="knob"                />
-    <widget name="lfo1Wave3Knob"              x="616"  y="413"                 d="40"         pic="knob"                />
+    <widget name="lfo1Wave1Knob"              x="616"  y="291"                 d="40"         pic="knob"                    />
+    <widget name="lfo1Wave2Knob"              x="616"  y="353"                 d="40"         pic="knob"                    />
+    <widget name="lfo1Wave3Knob"              x="616"  y="413"                 d="40"         pic="knob"                    />
 
-    <widget name="lfo1PWSlider"               x="598"  y="348" w="12"  h="47"         fh="9"  pic="slider-v"            />
+    <widget name="lfo1PWSlider"               x="598"  y="348" w="12"  h="47"         fh="9"  pic="slider-v"                />
 
-    <widget name="lfo1Wave2Label"             x="609"  y="396" w="54"  h="8"                  pic="label-lfo-wave2"     />
+    <widget name="lfo1Wave2Label"             x="609"  y="396" w="54"  h="8"                  pic="label-lfo-wave2"         />
 
-    <widget name="lfo1ToOsc1PitchButton"      x="692"  y="293" w="23"  h="35"                 pic="button-dual"         />
-    <widget name="lfo1ToOsc2PitchButton"      x="692"  y="355" w="23"  h="35"                 pic="button-dual"         />
-    <widget name="lfo1ToFilterCutoffButton"   x="692"  y="415" w="23"  h="35"                 pic="button-dual"         />
+    <widget name="lfo1ToOsc1PitchButton"      x="692"  y="293" w="23"  h="35"                 pic="button-dual"             />
+    <widget name="lfo1ToOsc2PitchButton"      x="692"  y="355" w="23"  h="35"                 pic="button-dual"             />
+    <widget name="lfo1ToFilterCutoffButton"   x="692"  y="415" w="23"  h="35"                 pic="button-dual"             />
 
-    <widget name="lfo1ToOsc1PWButton"         x="760"  y="293" w="23"  h="35"                 pic="button-dual"         />
-    <widget name="lfo1ToOsc2PWButton"         x="760"  y="355" w="23"  h="35"                 pic="button-dual"         />
-    <widget name="lfo1ToVolumeButton"         x="760"  y="415" w="23"  h="35"                 pic="button-dual"         />
+    <widget name="lfo1ToOsc1PWButton"         x="760"  y="293" w="23"  h="35"                 pic="button-dual"             />
+    <widget name="lfo1ToOsc2PWButton"         x="760"  y="355" w="23"  h="35"                 pic="button-dual"             />
+    <widget name="lfo1ToVolumeButton"         x="760"  y="415" w="23"  h="35"                 pic="button-dual"             />
 
-    <!-- LFO 2                                                                                                         -->
-    <widget name="lfo2TempoSyncButton"        x="601"  y="213" w="18"  h="13"                 pic="button-slim-alt"     />
+    <!-- LFO 2                                                                                                             -->
+    <widget name="lfo2TempoSyncButton"        x="601"  y="213" w="18"  h="13"                 pic="button-slim-alt"         />
 
-    <widget name="lfo2RateKnob"               x="616"  y="233"                 d="40"         pic="knob"                />
-    <widget name="lfo2ModAmount1Knob"         x="684"  y="233"                 d="40"         pic="knob"                />
-    <widget name="lfo2ModAmount2Knob"         x="752"  y="233"                 d="40"         pic="knob"                />
+    <widget name="lfo2RateKnob"               x="616"  y="233"                 d="40"         pic="knob"                    />
+    <widget name="lfo2ModAmount1Knob"         x="684"  y="233"                 d="40"         pic="knob"                    />
+    <widget name="lfo2ModAmount2Knob"         x="752"  y="233"                 d="40"         pic="knob"                    />
 
-    <widget name="lfo2Wave1Knob"              x="616"  y="291"                 d="40"         pic="knob"                />
-    <widget name="lfo2Wave2Knob"              x="616"  y="353"                 d="40"         pic="knob"                />
-    <widget name="lfo2Wave3Knob"              x="616"  y="413"                 d="40"         pic="knob"                />
+    <widget name="lfo2Wave1Knob"              x="616"  y="291"                 d="40"         pic="knob"                    />
+    <widget name="lfo2Wave2Knob"              x="616"  y="353"                 d="40"         pic="knob"                    />
+    <widget name="lfo2Wave3Knob"              x="616"  y="413"                 d="40"         pic="knob"                    />
 
-    <widget name="lfo2PWSlider"               x="598"  y="348" w="12"  h="47"         fh="9"  pic="slider-v"            />
+    <widget name="lfo2PWSlider"               x="598"  y="348" w="12"  h="47"         fh="9"  pic="slider-v"                />
 
-    <widget name="lfo2Wave2Label"             x="609"  y="396" w="54"  h="8"                  pic="label-lfo-wave2"     />
+    <widget name="lfo2Wave2Label"             x="609"  y="396" w="54"  h="8"                  pic="label-lfo-wave2"         />
 
-    <widget name="lfo2ToOsc1PitchButton"      x="692"  y="293" w="23"  h="35"                 pic="button-dual-alt"     />
-    <widget name="lfo2ToOsc2PitchButton"      x="692"  y="355" w="23"  h="35"                 pic="button-dual-alt"     />
-    <widget name="lfo2ToFilterCutoffButton"   x="692"  y="415" w="23"  h="35"                 pic="button-dual-alt"     />
+    <widget name="lfo2ToOsc1PitchButton"      x="692"  y="293" w="23"  h="35"                 pic="button-dual-alt"         />
+    <widget name="lfo2ToOsc2PitchButton"      x="692"  y="355" w="23"  h="35"                 pic="button-dual-alt"         />
+    <widget name="lfo2ToFilterCutoffButton"   x="692"  y="415" w="23"  h="35"                 pic="button-dual-alt"         />
 
-    <widget name="lfo2ToOsc1PWButton"         x="760"  y="293" w="23"  h="35"                 pic="button-dual-alt"     />
-    <widget name="lfo2ToOsc2PWButton"         x="760"  y="355" w="23"  h="35"                 pic="button-dual-alt"     />
-    <widget name="lfo2ToVolumeButton"         x="760"  y="415" w="23"  h="35"                 pic="button-dual-alt"     />
+    <widget name="lfo2ToOsc1PWButton"         x="760"  y="293" w="23"  h="35"                 pic="button-dual-alt"         />
+    <widget name="lfo2ToOsc2PWButton"         x="760"  y="355" w="23"  h="35"                 pic="button-dual-alt"         />
+    <widget name="lfo2ToVolumeButton"         x="760"  y="415" w="23"  h="35"                 pic="button-dual-alt"         />
 
-    <!-- FILTER ENVELOPE                                                                                               -->
-    <widget name="filterEnvInvertButton"      x="833"  y="20" w="18"   h="13"                 pic="button-slim"         />
+    <!-- FILTER ENVELOPE                                                                                                   -->
+    <widget name="filterEnvInvertButton"      x="833"  y="20" w="18"   h="13"                 pic="button-slim"             />
 
-    <widget name="filterEnvAttackKnob"        x="850"  y="48"                  d="40"         pic="knob"                />
-    <widget name="filterEnvDecayKnob"         x="919"  y="48"                  d="40"         pic="knob"                />
-    <widget name="filterEnvSustainKnob"       x="988"  y="48"                  d="40"         pic="knob"                />
-    <widget name="filterEnvReleaseKnob"       x="1057" y="48"                  d="40"         pic="knob"                />
+    <widget name="filterEnvAttackKnob"        x="850"  y="48"                  d="40"         pic="knob"                    />
+    <widget name="filterEnvDecayKnob"         x="919"  y="48"                  d="40"         pic="knob"                    />
+    <widget name="filterEnvSustainKnob"       x="988"  y="48"                  d="40"         pic="knob"                    />
+    <widget name="filterEnvReleaseKnob"       x="1057" y="48"                  d="40"         pic="knob"                    />
 
-    <widget name="filterEnvAttackCurveSlider" x="844"  y="111" w="47"  h="12"         fh="9"  pic="slider-h"            />
-    <widget name="velToFilterEnvSlider"       x="1052" y="111" w="47"  h="12"         fh="9"  pic="slider-h"            />
+    <widget name="filterEnvAttackCurveSlider" x="844"  y="111" w="47"  h="12"         fh="9"  pic="slider-h"                />
+    <widget name="velToFilterEnvSlider"       x="1052" y="111" w="47"  h="12"         fh="9"  pic="slider-h"                />
 
-    <!-- AMPLIFIER ENVELOPE                                                                                            -->
-    <widget name="ampEnvAttackKnob"           x="850"  y="175"                 d="40"         pic="knob"                />
-    <widget name="ampEnvDecayKnob"            x="919"  y="175"                 d="40"         pic="knob"                />
-    <widget name="ampEnvSustainKnob"          x="988"  y="175"                 d="40"         pic="knob"                />
-    <widget name="ampEnvReleaseKnob"          x="1057" y="175"                 d="40"         pic="knob"                />
+    <!-- AMPLIFIER ENVELOPE                                                                                                -->
+    <widget name="ampEnvAttackKnob"           x="850"  y="175"                 d="40"         pic="knob"                    />
+    <widget name="ampEnvDecayKnob"            x="919"  y="175"                 d="40"         pic="knob"                    />
+    <widget name="ampEnvSustainKnob"          x="988"  y="175"                 d="40"         pic="knob"                    />
+    <widget name="ampEnvReleaseKnob"          x="1057" y="175"                 d="40"         pic="knob"                    />
 
-    <widget name="ampEnvAttackCurveSlider"    x="844"  y="238" w="47"  h="12"         fh="9"  pic="slider-h"            />
-    <widget name="velToAmpEnvSlider"          x="1052" y="238" w="47"  h="12"         fh="9"  pic="slider-h"            />
+    <widget name="ampEnvAttackCurveSlider"    x="844"  y="238" w="47"  h="12"         fh="9"  pic="slider-h"                />
+    <widget name="velToAmpEnvSlider"          x="1052" y="238" w="47"  h="12"         fh="9"  pic="slider-h"                />
 
-    <!-- VOICE VARIATION                                                                                               -->
-    <widget name="portamentoSlopKnob"         x="850"  y="291"                 d="40"         pic="knob"                />
-    <widget name="filterSlopKnob"             x="919"  y="291"                 d="40"         pic="knob"                />
-    <widget name="envelopeSlopKnob"           x="988"  y="291"                 d="40"         pic="knob"                />
-    <widget name="levelSlopKnob"              x="1057" y="291"                 d="40"         pic="knob"                />
+    <!-- VOICE VARIATION                                                                                                   -->
+    <widget name="portamentoSlopKnob"         x="850"  y="291"                 d="40"         pic="knob"                    />
+    <widget name="filterSlopKnob"             x="919"  y="291"                 d="40"         pic="knob"                    />
+    <widget name="envelopeSlopKnob"           x="988"  y="291"                 d="40"         pic="knob"                    />
+    <widget name="levelSlopKnob"              x="1057" y="291"                 d="40"         pic="knob"                    />
 
-    <widget name="pan1Knob"                   x="850"  y="353"                 d="40"         pic="knob"                />
-    <widget name="pan2Knob"                   x="919"  y="353"                 d="40"         pic="knob"                />
-    <widget name="pan3Knob"                   x="988"  y="353"                 d="40"         pic="knob"                />
-    <widget name="pan4Knob"                   x="1057" y="353"                 d="40"         pic="knob"                />
+    <widget name="pan1Knob"                   x="850"  y="353"                 d="40"         pic="knob"                    />
+    <widget name="pan2Knob"                   x="919"  y="353"                 d="40"         pic="knob"                    />
+    <widget name="pan3Knob"                   x="988"  y="353"                 d="40"         pic="knob"                    />
+    <widget name="pan4Knob"                   x="1057" y="353"                 d="40"         pic="knob"                    />
 
-    <widget name="pan5Knob"                   x="850"  y="413"                 d="40"         pic="knob"                />
-    <widget name="pan6Knob"                   x="919"  y="413"                 d="40"         pic="knob"                />
-    <widget name="pan7Knob"                   x="988"  y="413"                 d="40"         pic="knob"                />
-    <widget name="pan8Knob"                   x="1057" y="413"                 d="40"         pic="knob"                />
+    <widget name="pan5Knob"                   x="850"  y="413"                 d="40"         pic="knob"                    />
+    <widget name="pan6Knob"                   x="919"  y="413"                 d="40"         pic="knob"                    />
+    <widget name="pan7Knob"                   x="988"  y="413"                 d="40"         pic="knob"                    />
+    <widget name="pan8Knob"                   x="1057" y="413"                 d="40"         pic="knob"                    />
 
-    <widget name="voice1LED"                  x="895"  y="354" w="9"   h="9"                  pic="label-led1"          />
-    <widget name="voice2LED"                  x="964"  y="354" w="9"   h="9"                  pic="label-led1"          />
-    <widget name="voice3LED"                  x="1033" y="354" w="9"   h="9"                  pic="label-led1"          />
-    <widget name="voice4LED"                  x="1102" y="354" w="9"   h="9"                  pic="label-led1"          />
+    <widget name="voice1LED"                  x="895"  y="354" w="9"   h="9"                  pic="label-led1"              />
+    <widget name="voice2LED"                  x="964"  y="354" w="9"   h="9"                  pic="label-led1"              />
+    <widget name="voice3LED"                  x="1033" y="354" w="9"   h="9"                  pic="label-led1"              />
+    <widget name="voice4LED"                  x="1102" y="354" w="9"   h="9"                  pic="label-led1"              />
 
-    <widget name="voice5LED"                  x="895"  y="414" w="9"   h="9"                  pic="label-led1"          />
-    <widget name="voice6LED"                  x="964"  y="414" w="9"   h="9"                  pic="label-led1"          />
-    <widget name="voice7LED"                  x="1033" y="414" w="9"   h="9"                  pic="label-led1"          />
-    <widget name="voice8LED"                  x="1102" y="414" w="9"   h="9"                  pic="label-led1"          />
+    <widget name="voice5LED"                  x="895"  y="414" w="9"   h="9"                  pic="label-led1"              />
+    <widget name="voice6LED"                  x="964"  y="414" w="9"   h="9"                  pic="label-led1"              />
+    <widget name="voice7LED"                  x="1033" y="414" w="9"   h="9"                  pic="label-led1"              />
+    <widget name="voice8LED"                  x="1102" y="414" w="9"   h="9"                  pic="label-led1"              />
 
-    <widget name="voice9LED"                  x="895"  y="364" w="9"   h="9"                  pic="label-led2"          />
-    <widget name="voice10LED"                 x="964"  y="364" w="9"   h="9"                  pic="label-led2"          />
-    <widget name="voice11LED"                 x="1033" y="364" w="9"   h="9"                  pic="label-led2"          />
-    <widget name="voice12LED"                 x="1102" y="364" w="9"   h="9"                  pic="label-led2"          />
+    <widget name="voice9LED"                  x="895"  y="364" w="9"   h="9"                  pic="label-led2"              />
+    <widget name="voice10LED"                 x="964"  y="364" w="9"   h="9"                  pic="label-led2"              />
+    <widget name="voice11LED"                 x="1033" y="364" w="9"   h="9"                  pic="label-led2"              />
+    <widget name="voice12LED"                 x="1102" y="364" w="9"   h="9"                  pic="label-led2"              />
 
-    <widget name="voice13LED"                 x="895"  y="424" w="9"   h="9"                  pic="label-led2"          />
-    <widget name="voice14LED"                 x="964"  y="424" w="9"   h="9"                  pic="label-led2"          />
-    <widget name="voice15LED"                 x="1033" y="424" w="9"   h="9"                  pic="label-led2"          />
-    <widget name="voice16LED"                 x="1102" y="424" w="9"   h="9"                  pic="label-led2"          />
+    <widget name="voice13LED"                 x="895"  y="424" w="9"   h="9"                  pic="label-led2"              />
+    <widget name="voice14LED"                 x="964"  y="424" w="9"   h="9"                  pic="label-led2"              />
+    <widget name="voice15LED"                 x="1033" y="424" w="9"   h="9"                  pic="label-led2"              />
+    <widget name="voice16LED"                 x="1102" y="424" w="9"   h="9"                  pic="label-led2"              />
 
-    <widget name="voice17LED"                 x="895"  y="374" w="9"   h="9"                  pic="label-led3"          />
-    <widget name="voice18LED"                 x="964"  y="374" w="9"   h="9"                  pic="label-led3"          />
-    <widget name="voice19LED"                 x="1033" y="374" w="9"   h="9"                  pic="label-led3"          />
-    <widget name="voice20LED"                 x="1102" y="374" w="9"   h="9"                  pic="label-led3"          />
+    <widget name="voice17LED"                 x="895"  y="374" w="9"   h="9"                  pic="label-led3"              />
+    <widget name="voice18LED"                 x="964"  y="374" w="9"   h="9"                  pic="label-led3"              />
+    <widget name="voice19LED"                 x="1033" y="374" w="9"   h="9"                  pic="label-led3"              />
+    <widget name="voice20LED"                 x="1102" y="374" w="9"   h="9"                  pic="label-led3"              />
 
-    <widget name="voice21LED"                 x="895"  y="434" w="9"   h="9"                  pic="label-led3"          />
-    <widget name="voice22LED"                 x="964"  y="434" w="9"   h="9"                  pic="label-led3"          />
-    <widget name="voice23LED"                 x="1033" y="434" w="9"   h="9"                  pic="label-led3"          />
-    <widget name="voice24LED"                 x="1102" y="434" w="9"   h="9"                  pic="label-led3"          />
+    <widget name="voice21LED"                 x="895"  y="434" w="9"   h="9"                  pic="label-led3"              />
+    <widget name="voice22LED"                 x="964"  y="434" w="9"   h="9"                  pic="label-led3"              />
+    <widget name="voice23LED"                 x="1033" y="434" w="9"   h="9"                  pic="label-led3"              />
+    <widget name="voice24LED"                 x="1102" y="434" w="9"   h="9"                  pic="label-led3"              />
 
-    <widget name="voice25LED"                 x="895"  y="384" w="9"   h="9"                  pic="label-led4"          />
-    <widget name="voice26LED"                 x="964"  y="384" w="9"   h="9"                  pic="label-led4"          />
-    <widget name="voice27LED"                 x="1033" y="384" w="9"   h="9"                  pic="label-led4"          />
-    <widget name="voice28LED"                 x="1102" y="384" w="9"   h="9"                  pic="label-led4"          />
+    <widget name="voice25LED"                 x="895"  y="384" w="9"   h="9"                  pic="label-led4"              />
+    <widget name="voice26LED"                 x="964"  y="384" w="9"   h="9"                  pic="label-led4"              />
+    <widget name="voice27LED"                 x="1033" y="384" w="9"   h="9"                  pic="label-led4"              />
+    <widget name="voice28LED"                 x="1102" y="384" w="9"   h="9"                  pic="label-led4"              />
 
-    <widget name="voice29LED"                 x="895"  y="444" w="9"   h="9"                  pic="label-led4"          />
-    <widget name="voice30LED"                 x="964"  y="444" w="9"   h="9"                  pic="label-led4"          />
-    <widget name="voice31LED"                 x="1033" y="444" w="9"   h="9"                  pic="label-led4"          />
-    <widget name="voice32LED"                 x="1102" y="444" w="9"   h="9"                  pic="label-led4"          />
+    <widget name="voice29LED"                 x="895"  y="444" w="9"   h="9"                  pic="label-led4"              />
+    <widget name="voice30LED"                 x="964"  y="444" w="9"   h="9"                  pic="label-led4"              />
+    <widget name="voice31LED"                 x="1033" y="444" w="9"   h="9"                  pic="label-led4"              />
+    <widget name="voice32LED"                 x="1102" y="444" w="9"   h="9"                  pic="label-led4"              />
 
-    <!-- PROGRAMMER                                                                                                    -->
-    <widget name="patchNumberMenu"            x="56"   y="506" w="43"  h="31"                                           /> <!-- pic="menu-patch"  -->
+    <!-- PROGRAMMER                                                                                                        -->
+    <widget name="patchNumberMenu"            x="56"   y="506" w="43"  h="31"                                               /> <!-- pic="menu-patch"  -->
 
-    <widget name="patchNameLabel"             x="103"  y="506" w="166" h="31"                 color="FFFF0000"          /> <!-- color is AARRGGBB -->
+    <widget name="patchNameLabel"             x="103"  y="506" w="166" h="31"                 color="FFFF0000"              /> <!-- color is AARRGGBB -->
 
-    <widget name="prevPatchButton"            x="294"  y="504" w="23"  h="35"                 pic="button-clear"        />
-    <widget name="nextPatchButton"            x="327"  y="504" w="23"  h="35"                 pic="button-clear"        />
+    <widget name="prevPatchButton"            x="294"  y="504" w="23"  h="35"                 pic="button-clear"            />
+    <widget name="nextPatchButton"            x="327"  y="504" w="23"  h="35"                 pic="button-clear"            />
 
-    <widget name="savePatchButton"            x="372"  y="504" w="23"  h="35"                 pic="button-clear-red"    />
-    <widget name="undoPatchButton"            x="405"  y="504" w="23"  h="35"                 pic="button-clear"        />
+    <widget name="savePatchButton"            x="372"  y="504" w="23"  h="35"                 pic="button-clear-red"        />
+    <widget name="undoPatchButton"            x="405"  y="504" w="23"  h="35"                 pic="button-clear"            />
 
-    <widget name="initPatchButton"            x="450"  y="504" w="23"  h="35"                 pic="button-clear-white"  />
-    <widget name="randomizePatchButton"       x="483"  y="504" w="23"  h="35"                 pic="button-clear"        />
+    <widget name="initPatchButton"            x="450"  y="504" w="23"  h="35"                 pic="button-clear-white"      />
+    <widget name="randomizePatchButton"       x="483"  y="504" w="23"  h="35"                 pic="button-clear"            />
 
-    <widget name="groupSelectButton"          x="530"  y="504" w="23"  h="35"                 pic="button-alt"          />
+    <widget name="groupSelectButton"          x="530"  y="504" w="23"  h="35"                 pic="button-alt"              />
 
-    <!-- These buttons are ALWAYS using button-group-patch.png!                                                        -->
-    <widget name="select1Button"              x="578"  y="504" w="23"  h="35"                                           /> <!-- pic="button-group-patch" -->
-    <widget name="select2Button"              x="611"  y="504" w="23"  h="35"                                           /> <!-- pic="button-group-patch" -->
-    <widget name="select3Button"              x="644"  y="504" w="23"  h="35"                                           /> <!-- pic="button-group-patch" -->
-    <widget name="select4Button"              x="677"  y="504" w="23"  h="35"                                           /> <!-- pic="button-group-patch" -->
-    <widget name="select5Button"              x="710"  y="504" w="23"  h="35"                                           /> <!-- pic="button-group-patch" -->
-    <widget name="select6Button"              x="743"  y="504" w="23"  h="35"                                           /> <!-- pic="button-group-patch" -->
-    <widget name="select7Button"              x="776"  y="504" w="23"  h="35"                                           /> <!-- pic="button-group-patch" -->
-    <widget name="select8Button"              x="809"  y="504" w="23"  h="35"                                           /> <!-- pic="button-group-patch" -->
-    <widget name="select9Button"              x="842"  y="504" w="23"  h="35"                                           /> <!-- pic="button-group-patch" -->
-    <widget name="select10Button"             x="875"  y="504" w="23"  h="35"                                           /> <!-- pic="button-group-patch" -->
-    <widget name="select11Button"             x="908"  y="504" w="23"  h="35"                                           /> <!-- pic="button-group-patch" -->
-    <widget name="select12Button"             x="941"  y="504" w="23"  h="35"                                           /> <!-- pic="button-group-patch" -->
-    <widget name="select13Button"             x="974"  y="504" w="23"  h="35"                                           /> <!-- pic="button-group-patch" -->
-    <widget name="select14Button"             x="1007" y="504" w="23"  h="35"                                           /> <!-- pic="button-group-patch" -->
-    <widget name="select15Button"             x="1040" y="504" w="23"  h="35"                                           /> <!-- pic="button-group-patch" -->
-    <widget name="select16Button"             x="1073" y="504" w="23"  h="35"                                           /> <!-- pic="button-group-patch" -->
+    <!-- These buttons are ALWAYS using button-group-patch.png!                                                            -->
+    <widget name="select1Button"              x="578"  y="504" w="23"  h="35"                                               /> <!-- pic="button-group-patch" -->
+    <widget name="select2Button"              x="611"  y="504" w="23"  h="35"                                               /> <!-- pic="button-group-patch" -->
+    <widget name="select3Button"              x="644"  y="504" w="23"  h="35"                                               /> <!-- pic="button-group-patch" -->
+    <widget name="select4Button"              x="677"  y="504" w="23"  h="35"                                               /> <!-- pic="button-group-patch" -->
+    <widget name="select5Button"              x="710"  y="504" w="23"  h="35"                                               /> <!-- pic="button-group-patch" -->
+    <widget name="select6Button"              x="743"  y="504" w="23"  h="35"                                               /> <!-- pic="button-group-patch" -->
+    <widget name="select7Button"              x="776"  y="504" w="23"  h="35"                                               /> <!-- pic="button-group-patch" -->
+    <widget name="select8Button"              x="809"  y="504" w="23"  h="35"                                               /> <!-- pic="button-group-patch" -->
+    <widget name="select9Button"              x="842"  y="504" w="23"  h="35"                                               /> <!-- pic="button-group-patch" -->
+    <widget name="select10Button"             x="875"  y="504" w="23"  h="35"                                               /> <!-- pic="button-group-patch" -->
+    <widget name="select11Button"             x="908"  y="504" w="23"  h="35"                                               /> <!-- pic="button-group-patch" -->
+    <widget name="select12Button"             x="941"  y="504" w="23"  h="35"                                               /> <!-- pic="button-group-patch" -->
+    <widget name="select13Button"             x="974"  y="504" w="23"  h="35"                                               /> <!-- pic="button-group-patch" -->
+    <widget name="select14Button"             x="1007" y="504" w="23"  h="35"                                               /> <!-- pic="button-group-patch" -->
+    <widget name="select15Button"             x="1040" y="504" w="23"  h="35"                                               /> <!-- pic="button-group-patch" -->
+    <widget name="select16Button"             x="1073" y="504" w="23"  h="35"                                               /> <!-- pic="button-group-patch" -->
 
-    <!-- SAVE PATCH DIALOG                                                                                             -->
-    <widget name="savePatchDialog"                             w="246" h="328"                                          /> <!-- pic="label-bg-save-patch" -->
-    <widget name="savePatchNameLabel"         x="22"   y="29"  w="200" h="31"                 color="FFFF0000"          /> <!-- color is AARRGGBB         -->
-    <widget name="savePatchAuthorLabel"       x="22"   y="90"  w="200" h="31"                 color="FFFF0000"          /> <!-- color is AARRGGBB         -->
-    <widget name="savePatchProjectLabel"      x="22"   y="151" w="200" h="31"                 color="FFFF0000"          /> <!-- color is AARRGGBB         -->
-    <widget name="savePatchCategoryMenu"      x="25"   y="212" w="90"  h="31"                                           /> <!-- pic="menu-categories"     -->
-    <widget name="savePatchLicenseLabel"      x="126"  y="212" w="96"  h="31"                 color="FFFF0000"          /> <!-- color is AARRGGBB         -->
-    <widget name="savePatchOKButton"          x="92"   y="272" w="23"  h="35"                                           /> <!-- pic="button-clear-red"    -->
-    <widget name="savePatchCancelButton"      x="129"  y="272" w="23"  h="35"                                           /> <!-- pic="button-clear-white"  -->
+    <!-- SAVE PATCH DIALOG                                                                                                 -->
+    <widget name="savePatchDialog"                             w="246" h="328"                                              /> <!-- pic="label-bg-save-patch" -->
+    <widget name="savePatchNameLabel"         x="22"   y="29"  w="200" h="31"                 color="FFFF0000"              /> <!-- color is AARRGGBB         -->
+    <widget name="savePatchAuthorLabel"       x="22"   y="90"  w="200" h="31"                 color="FFFF0000"              /> <!-- color is AARRGGBB         -->
+    <widget name="savePatchProjectLabel"      x="22"   y="151" w="200" h="31"                 color="FFFF0000"              /> <!-- color is AARRGGBB         -->
+    <widget name="savePatchCategoryMenu"      x="25"   y="212" w="90"  h="31"                                               /> <!-- pic="menu-categories"     -->
+    <widget name="savePatchLicenseLabel"      x="126"  y="212" w="96"  h="31"                 color="FFFF0000"              /> <!-- color is AARRGGBB         -->
+    <widget name="savePatchOKButton"          x="92"   y="272" w="23"  h="35"                                               /> <!-- pic="button-clear-red"    -->
+    <widget name="savePatchCancelButton"      x="129"  y="272" w="23"  h="35"                                               /> <!-- pic="button-clear-white"  -->
 </obxf-theme>

--- a/assets/installer/Surge Synth Team/OB-Xf/Themes/Default/theme.xml
+++ b/assets/installer/Surge Synth Team/OB-Xf/Themes/Default/theme.xml
@@ -25,266 +25,266 @@ However, if you omit the "pic" argument everywhere, the theme will still work be
 -->
 
 <obxf-theme>
-    <widget name="aboutPage"                  x="30"   y="14"  w="220" h="74"                                           /> <!-- only acts as a click area! -->
+    <widget name="aboutPage"                  x="30"   y="14"  w="220" h="74"                                               /> <!-- only acts as a click area! -->
 
-    <!-- MASTER                                                                                                        -->
-    <widget name="masterBGLabel"              x="34"   y="204" w="218" h="84"                 pic="label-bg-master"     />
-    <widget name="volumeKnob"                 x="52"   y="127"                 d="40"         pic="knob"                />
-    <widget name="transposeKnob"              x="120"  y="127"                 d="40"         pic="knob"                />
-    <widget name="tuneKnob"                   x="188"  y="127"                 d="40"         pic="knob"                />
+    <!-- MASTER                                                                                                            -->
+    <widget name="masterBGLabel"              x="34"   y="204" w="218" h="84"                 pic="label-bg-master"         />
+    <widget name="volumeKnob"                 x="52"   y="127"                 d="40"         pic="knob"                    />
+    <widget name="transposeKnob"              x="120"  y="127"                 d="40"         pic="knob"                    />
+    <widget name="tuneKnob"                   x="188"  y="127"                 d="40"         pic="knob"                    />
 
-    <!-- GLOBAL                                                                                                        -->
-    <widget name="globalBGLabel"              x="34"   y="204" w="218" h="268"                pic="label-bg-global"     />
-    <widget name="polyphonyMenu"              x="56"   y="235" w="31"  h="31"                                           /> <!-- pic="menu-poly" -->
-    <widget name="hqModeButton"               x="128"  y="233" w="23"  h="35"                 pic="button"              />
-    <widget name="lockHQButton"               x="154"  y="272" w="11"  h="11"                 pic="button-lock"         />
-    <widget name="unisonVoicesMenu"           x="192"  y="235" w="31"  h="31"                                           /> <!-- pic="menu-poly" -->
+    <!-- GLOBAL                                                                                                            -->
+    <widget name="globalBGLabel"              x="34"   y="204" w="218" h="268"                pic="label-bg-global"         />
+    <widget name="polyphonyMenu"              x="56"   y="235" w="31"  h="31"                                               /> <!-- pic="menu-poly" -->
+    <widget name="hqModeButton"               x="128"  y="233" w="23"  h="35"                 pic="button"                  />
+    <widget name="lockHQButton"               x="154"  y="272" w="11"  h="11"                 pic="button-lock"             />
+    <widget name="unisonVoicesMenu"           x="192"  y="235" w="31"  h="31"                                               /> <!-- pic="menu-poly" -->
 
-    <widget name="portamentoKnob"             x="52"   y="291"                 d="40"         pic="knob"                />
-    <widget name="unisonButton"               x="128"  y="293" w="23"  h="35"                 pic="button"              />
-    <widget name="unisonDetuneKnob"           x="188"  y="291"                 d="40"         pic="knob"                />
+    <widget name="portamentoKnob"             x="52"   y="291"                 d="40"         pic="knob"                    />
+    <widget name="unisonButton"               x="128"  y="293" w="23"  h="35"                 pic="button"                  />
+    <widget name="unisonDetuneKnob"           x="188"  y="291"                 d="40"         pic="knob"                    />
 
-    <widget name="envLegatoModeMenu"          x="56"   y="357" w="90"  h="31"                                           /> <!-- pic="menu-legato"        -->
-    <widget name="notePriorityMenu"           x="161"  y="357" w="64"  h="31"                                           /> <!-- pic="menu-note-priority" -->
+    <widget name="envLegatoModeMenu"          x="56"   y="357" w="90"  h="31"                                               /> <!-- pic="menu-legato"        -->
+    <widget name="notePriorityMenu"           x="161"  y="357" w="64"  h="31"                                               /> <!-- pic="menu-note-priority" -->
 
-    <widget name="mainMenu"                   x="60"   y="415" w="23"  h="35"                 pic="button-clear-red"    />
-    <widget name="midiLearnButton"            x="196"  y="415" w="23"  h="35"                 pic="button"              />
+    <widget name="mainMenu"                   x="60"   y="415" w="23"  h="35"                 pic="button-clear-red"        />
+    <widget name="midiLearnButton"            x="196"  y="415" w="23"  h="35"                 pic="button"                  />
 
-    <!-- OSCILLATORS                                                                                                   -->
-    <widget name="osc1PitchKnob"              x="287"  y="48"                  d="40"         pic="knob"                />
-    <widget name="osc2DetuneKnob"             x="354"  y="48"                  d="40"         pic="knob"                />
-    <widget name="osc2PitchKnob"              x="422"  y="48"                  d="40"         pic="knob"                />
-    <widget name="osc2KeytrackButton"         x="463"  y="91"  w="11"  h="11"                 pic="button-keytrack"     />
+    <!-- OSCILLATORS                                                                                                       -->
+    <widget name="osc1PitchKnob"              x="287"  y="48"                  d="40"         pic="knob"                    />
+    <widget name="osc2DetuneKnob"             x="354"  y="48"                  d="40"         pic="knob"                    />
+    <widget name="osc2PitchKnob"              x="422"  y="48"                  d="40"         pic="knob"                    />
+    <widget name="osc2KeytrackButton"         x="463"  y="91"  w="11"  h="11"                 pic="button-keytrack"         />
 
-    <widget name="osc1SawButton"              x="277"  y="129" w="23"  h="35"                 pic="button"              />
-    <widget name="osc1PulseButton"            x="314"  y="129" w="23"  h="35"                 pic="button"              />
+    <widget name="osc1SawButton"              x="277"  y="129" w="23"  h="35"                 pic="button"                  />
+    <widget name="osc1PulseButton"            x="314"  y="129" w="23"  h="35"                 pic="button"                  />
 
-    <widget name="osc1TriangleLabel"          x="299"  y="170" w="16"  h="10"                 pic="label-osc-triangle"  />
-    <widget name="osc1PulseLabel"             x="319"  y="171" w="14"  h="8"                  pic="label-osc-pulse"     />
+    <widget name="osc1TriangleLabel"          x="299"  y="170" w="16"  h="10"                 pic="label-osc-triangle"      />
+    <widget name="osc1PulseLabel"             x="319"  y="171" w="14"  h="8"                  pic="label-osc-pulse"         />
 
-    <widget name="osc2SawButton"              x="412"  y="129" w="23"  h="35"                 pic="button"              />
-    <widget name="osc2PulseButton"            x="449"  y="129" w="23"  h="35"                 pic="button"              />
+    <widget name="osc2SawButton"              x="412"  y="129" w="23"  h="35"                 pic="button"                  />
+    <widget name="osc2PulseButton"            x="449"  y="129" w="23"  h="35"                 pic="button"                  />
 
-    <widget name="osc2TriangleLabel"          x="434"  y="170" w="16"  h="10"                 pic="label-osc-triangle"  />
-    <widget name="osc2PulseLabel"             x="454"  y="171" w="14"  h="8"                  pic="label-osc-pulse"     />
+    <widget name="osc2TriangleLabel"          x="434"  y="170" w="16"  h="10"                 pic="label-osc-triangle"      />
+    <widget name="osc2PulseLabel"             x="454"  y="171" w="14"  h="8"                  pic="label-osc-pulse"         />
 
-    <widget name="oscPWKnob"                  x="354"  y="127"                 d="40"         pic="knob"                />
-    <widget name="osc2PWOffsetKnob"           x="354"  y="218"                 d="40"         pic="knob"                />
+    <widget name="oscPWKnob"                  x="354"  y="127"                 d="40"         pic="knob"                    />
+    <widget name="osc2PWOffsetKnob"           x="354"  y="218"                 d="40"         pic="knob"                    />
 
-    <widget name="envToPitchAmountKnob"       x="287"  y="218"                 d="40"         pic="knob"                />
-    <widget name="envToPitchBothOscsButton"   x="279"  y="187" w="18"  h="13"                 pic="button-slim"         />
-    <widget name="envToPitchInvertButton"     x="316"  y="187" w="18"  h="13"                 pic="button-slim"         />
+    <widget name="envToPitchAmountKnob"       x="287"  y="218"                 d="40"         pic="knob"                    />
+    <widget name="envToPitchBothOscsButton"   x="279"  y="187" w="18"  h="13"                 pic="button-slim"             />
+    <widget name="envToPitchInvertButton"     x="316"  y="187" w="18"  h="13"                 pic="button-slim"             />
 
-    <widget name="envToPWAmountKnob"          x="422"  y="218"                 d="40"         pic="knob"                />
-    <widget name="envToPWBothOscsButton"      x="452"  y="187" w="18"  h="13"                 pic="button-slim"         />
-    <widget name="envToPWInvertButton"        x="415"  y="187" w="18"  h="13"                 pic="button-slim"         />
+    <widget name="envToPWAmountKnob"          x="422"  y="218"                 d="40"         pic="knob"                    />
+    <widget name="envToPWBothOscsButton"      x="452"  y="187" w="18"  h="13"                 pic="button-slim"             />
+    <widget name="envToPWInvertButton"        x="415"  y="187" w="18"  h="13"                 pic="button-slim"             />
 
-    <widget name="oscCrossmodKnob"            x="287"  y="291"                 d="40"         pic="knob"                />
-    <widget name="oscSyncButton"              x="363"  y="293" w="23"  h="35"                 pic="button"              />
-    <widget name="oscBrightnessKnob"          x="422"  y="291"                 d="40"         pic="knob"                />
+    <widget name="oscCrossmodKnob"            x="287"  y="291"                 d="40"         pic="knob"                    />
+    <widget name="oscSyncButton"              x="363"  y="293" w="23"  h="35"                 pic="button"                  />
+    <widget name="oscBrightnessKnob"          x="422"  y="291"                 d="40"         pic="knob"                    />
 
-    <!-- MIXER                                                                                                         -->
-    <widget name="osc1VolKnob"                x="520"  y="48"                  d="40"         pic="knob"                />
-    <widget name="osc2VolKnob"                x="520"  y="127"                 d="40"         pic="knob"                />
-    <widget name="ringModVolKnob"             x="520"  y="218"                 d="40"         pic="knob"                />
-    <widget name="noiseVolKnob"               x="520"  y="291"                 d="40"         pic="knob"                />
-    <widget name="noiseColorButton"           x="504"  y="333" w="18"  h="13"                 pic="button-slim-noise"   />
+    <!-- MIXER                                                                                                             -->
+    <widget name="osc1VolKnob"                x="520"  y="48"                  d="40"         pic="knob"                    />
+    <widget name="osc2VolKnob"                x="520"  y="127"                 d="40"         pic="knob"                    />
+    <widget name="ringModVolKnob"             x="520"  y="218"                 d="40"         pic="knob"                    />
+    <widget name="noiseVolKnob"               x="520"  y="291"                 d="40"         pic="knob"                    />
+    <widget name="noiseColorButton"           x="504"  y="333" w="18"  h="13"                 pic="button-slim-noise"       />
 
-    <!-- CONTROL                                                                                                       -->
-    <widget name="bendDownRangeMenu"          x="291"  y="417" w="31"  h="31"                                           /> <!-- pic="menu-pitch-bend" -->
-    <widget name="bendUpRangeMenu"            x="359"  y="417" w="31"  h="31"                                           /> <!-- pic="menu-pitch-bend" -->
-    <widget name="bendOsc2OnlyButton"         x="431"  y="415" w="23"  h="35"                 pic="button"              />
-    <widget name="lockBendRangeButton"        x="335"  y="427" w="11"  h="11"                 pic="button-lock"         />
+    <!-- CONTROL                                                                                                           -->
+    <widget name="bendDownRangeMenu"          x="291"  y="417" w="31"  h="31"                                               /> <!-- pic="menu-pitch-bend" -->
+    <widget name="bendUpRangeMenu"            x="359"  y="417" w="31"  h="31"                                               /> <!-- pic="menu-pitch-bend" -->
+    <widget name="bendOsc2OnlyButton"         x="431"  y="415" w="23"  h="35"                 pic="button"                  />
+    <widget name="lockBendRangeButton"        x="335"  y="427" w="11"  h="11"                 pic="button-lock"             />
 
-    <widget name="vibratoWaveButton"          x="491"  y="426" w="18"  h="13"                 pic="button-slim"         />
-    <widget name="vibratoRateKnob"            x="520"  y="413"                 d="40"         pic="knob"                />
+    <widget name="vibratoWaveButton"          x="491"  y="426" w="18"  h="13"                 pic="button-slim-vibrato-wave"/>
+    <widget name="vibratoRateKnob"            x="520"  y="413"                 d="40"         pic="knob"                    />
 
-    <!-- FILTER                                                                                                        -->
-    <widget name="filter4PoleModeButton"      x="601"  y="20"  w="18"  h="13"                 pic="button-slim"         />
+    <!-- FILTER                                                                                                            -->
+    <widget name="filter4PoleModeButton"      x="601"  y="20"  w="18"  h="13"                 pic="button-slim"             />
 
-    <widget name="filterCutoffKnob"           x="616"  y="48"                  d="40"         pic="knob"                />
-    <widget name="filterResonanceKnob"        x="684"  y="48"                  d="40"         pic="knob"                />
-    <widget name="filterEnvAmountKnob"        x="752"  y="48"                  d="40"         pic="knob"                />
+    <widget name="filterCutoffKnob"           x="616"  y="48"                  d="40"         pic="knob"                    />
+    <widget name="filterResonanceKnob"        x="684"  y="48"                  d="40"         pic="knob"                    />
+    <widget name="filterEnvAmountKnob"        x="752"  y="48"                  d="40"         pic="knob"                    />
 
-    <widget name="filterKeyTrackKnob"         x="616"  y="127"                 d="40"         pic="knob"                />
-    <widget name="filterModeKnob"             x="684"  y="127"                 d="40"         pic="knob"                />
+    <widget name="filterKeyTrackKnob"         x="616"  y="127"                 d="40"         pic="knob"                    />
+    <widget name="filterModeKnob"             x="684"  y="127"                 d="40"         pic="knob"                    />
 
-    <widget name="filter2PoleBPBlendButton"   x="748"  y="131" w="18"  h="13"                 pic="button-slim"         />
-    <widget name="filter2PolePushButton"      x="748"  y="151" w="18"  h="13"                 pic="button-slim"         />
+    <widget name="filter2PoleBPBlendButton"   x="748"  y="131" w="18"  h="13"                 pic="button-slim"             />
+    <widget name="filter2PolePushButton"      x="748"  y="151" w="18"  h="13"                 pic="button-slim"             />
 
-    <widget name="filter4PoleXpanderButton"   x="760"  y="129" w="23"  h="35"                 pic="button"              />
-    <widget name="filterXpanderModeMenu"      x="673"  y="131" w="62"  h="31"                                           /> <!-- pic="menu-xpander"         -->
+    <widget name="filter4PoleXpanderButton"   x="760"  y="129" w="23"  h="35"                 pic="button"                  />
+    <widget name="filterXpanderModeMenu"      x="673"  y="131" w="62"  h="31"                                               /> <!-- pic="menu-xpander"         -->
 
-    <widget name="filterModeLabel"            x="669"  y="119" w="70"  h="56"                                           /> <!-- pic="label-filter-mode"    -->
-    <widget name="filterOptionsLabel"         x="746"  y="127" w="54"  h="54"                                           /> <!-- pic="label-filter-options" -->
+    <widget name="filterModeLabel"            x="669"  y="119" w="70"  h="56"                                               /> <!-- pic="label-filter-mode"    -->
+    <widget name="filterOptionsLabel"         x="746"  y="127" w="54"  h="54"                                               /> <!-- pic="label-filter-options" -->
 
-    <!-- LFOS                                                                                                          -->
-    <widget name="lfo1SelectButton"           x="757"  y="213" w="18"  h="13"                 pic="button-slim"         />
-    <widget name="lfo2SelectButton"           x="789"  y="213" w="18"  h="13"                 pic="button-slim-alt"     />
+    <!-- LFOS                                                                                                              -->
+    <widget name="lfo1SelectButton"           x="757"  y="213" w="18"  h="13"                 pic="button-slim"             />
+    <widget name="lfo2SelectButton"           x="789"  y="213" w="18"  h="13"                 pic="button-slim-alt"         />
 
-    <!-- LFO 1                                                                                                         -->
-    <widget name="lfo1TempoSyncButton"        x="601"  y="213" w="18"  h="13"                 pic="button-slim"         />
+    <!-- LFO 1                                                                                                             -->
+    <widget name="lfo1TempoSyncButton"        x="601"  y="213" w="18"  h="13"                 pic="button-slim"             />
 
-    <widget name="lfo1RateKnob"               x="616"  y="233"                 d="40"         pic="knob"                />
-    <widget name="lfo1ModAmount1Knob"         x="684"  y="233"                 d="40"         pic="knob"                />
-    <widget name="lfo1ModAmount2Knob"         x="752"  y="233"                 d="40"         pic="knob"                />
+    <widget name="lfo1RateKnob"               x="616"  y="233"                 d="40"         pic="knob"                    />
+    <widget name="lfo1ModAmount1Knob"         x="684"  y="233"                 d="40"         pic="knob"                    />
+    <widget name="lfo1ModAmount2Knob"         x="752"  y="233"                 d="40"         pic="knob"                    />
 
-    <widget name="lfo1Wave1Knob"              x="616"  y="291"                 d="40"         pic="knob"                />
-    <widget name="lfo1Wave2Knob"              x="616"  y="353"                 d="40"         pic="knob"                />
-    <widget name="lfo1Wave3Knob"              x="616"  y="413"                 d="40"         pic="knob"                />
+    <widget name="lfo1Wave1Knob"              x="616"  y="291"                 d="40"         pic="knob"                    />
+    <widget name="lfo1Wave2Knob"              x="616"  y="353"                 d="40"         pic="knob"                    />
+    <widget name="lfo1Wave3Knob"              x="616"  y="413"                 d="40"         pic="knob"                    />
 
-    <widget name="lfo1PWSlider"               x="598"  y="348" w="13"  h="50"         fh="50" pic="slider-v"            />
+    <widget name="lfo1PWSlider"               x="598"  y="348" w="13"  h="50"         fh="50" pic="slider-v"                />
 
-    <widget name="lfo1Wave2Label"             x="609"  y="396" w="54"  h="8"                  pic="label-lfo-wave2"     />
+    <widget name="lfo1Wave2Label"             x="609"  y="396" w="54"  h="8"                  pic="label-lfo-wave2"         />
 
-    <widget name="lfo1ToOsc1PitchButton"      x="692"  y="293" w="23"  h="35"                 pic="button-dual"         />
-    <widget name="lfo1ToOsc2PitchButton"      x="692"  y="355" w="23"  h="35"                 pic="button-dual"         />
-    <widget name="lfo1ToFilterCutoffButton"   x="692"  y="415" w="23"  h="35"                 pic="button-dual"         />
+    <widget name="lfo1ToOsc1PitchButton"      x="692"  y="293" w="23"  h="35"                 pic="button-dual"             />
+    <widget name="lfo1ToOsc2PitchButton"      x="692"  y="355" w="23"  h="35"                 pic="button-dual"             />
+    <widget name="lfo1ToFilterCutoffButton"   x="692"  y="415" w="23"  h="35"                 pic="button-dual"             />
 
-    <widget name="lfo1ToOsc1PWButton"         x="760"  y="293" w="23"  h="35"                 pic="button-dual"         />
-    <widget name="lfo1ToOsc2PWButton"         x="760"  y="355" w="23"  h="35"                 pic="button-dual"         />
-    <widget name="lfo1ToVolumeButton"         x="760"  y="415" w="23"  h="35"                 pic="button-dual"         />
+    <widget name="lfo1ToOsc1PWButton"         x="760"  y="293" w="23"  h="35"                 pic="button-dual"             />
+    <widget name="lfo1ToOsc2PWButton"         x="760"  y="355" w="23"  h="35"                 pic="button-dual"             />
+    <widget name="lfo1ToVolumeButton"         x="760"  y="415" w="23"  h="35"                 pic="button-dual"             />
 
-    <!-- LFO 2                                                                                                         -->
-    <widget name="lfo2TempoSyncButton"        x="601"  y="213" w="18"  h="13"                 pic="button-slim-alt"     />
+    <!-- LFO 2                                                                                                             -->
+    <widget name="lfo2TempoSyncButton"        x="601"  y="213" w="18"  h="13"                 pic="button-slim-alt"         />
 
-    <widget name="lfo2RateKnob"               x="616"  y="233"                 d="40"         pic="knob"                />
-    <widget name="lfo2ModAmount1Knob"         x="684"  y="233"                 d="40"         pic="knob"                />
-    <widget name="lfo2ModAmount2Knob"         x="752"  y="233"                 d="40"         pic="knob"                />
+    <widget name="lfo2RateKnob"               x="616"  y="233"                 d="40"         pic="knob"                    />
+    <widget name="lfo2ModAmount1Knob"         x="684"  y="233"                 d="40"         pic="knob"                    />
+    <widget name="lfo2ModAmount2Knob"         x="752"  y="233"                 d="40"         pic="knob"                    />
 
-    <widget name="lfo2Wave1Knob"              x="616"  y="291"                 d="40"         pic="knob"                />
-    <widget name="lfo2Wave2Knob"              x="616"  y="353"                 d="40"         pic="knob"                />
-    <widget name="lfo2Wave3Knob"              x="616"  y="413"                 d="40"         pic="knob"                />
+    <widget name="lfo2Wave1Knob"              x="616"  y="291"                 d="40"         pic="knob"                    />
+    <widget name="lfo2Wave2Knob"              x="616"  y="353"                 d="40"         pic="knob"                    />
+    <widget name="lfo2Wave3Knob"              x="616"  y="413"                 d="40"         pic="knob"                    />
 
-    <widget name="lfo2PWSlider"               x="598"  y="348" w="13"  h="50"         fh="50" pic="slider-v"            />
+    <widget name="lfo2PWSlider"               x="598"  y="348" w="13"  h="50"         fh="50" pic="slider-v"                />
 
-    <widget name="lfo2Wave2Label"             x="609"  y="396" w="54"  h="8"                  pic="label-lfo-wave2"     />
+    <widget name="lfo2Wave2Label"             x="609"  y="396" w="54"  h="8"                  pic="label-lfo-wave2"         />
 
-    <widget name="lfo2ToOsc1PitchButton"      x="692"  y="293" w="23"  h="35"                 pic="button-dual-alt"     />
-    <widget name="lfo2ToOsc2PitchButton"      x="692"  y="355" w="23"  h="35"                 pic="button-dual-alt"     />
-    <widget name="lfo2ToFilterCutoffButton"   x="692"  y="415" w="23"  h="35"                 pic="button-dual-alt"     />
+    <widget name="lfo2ToOsc1PitchButton"      x="692"  y="293" w="23"  h="35"                 pic="button-dual-alt"         />
+    <widget name="lfo2ToOsc2PitchButton"      x="692"  y="355" w="23"  h="35"                 pic="button-dual-alt"         />
+    <widget name="lfo2ToFilterCutoffButton"   x="692"  y="415" w="23"  h="35"                 pic="button-dual-alt"         />
 
-    <widget name="lfo2ToOsc1PWButton"         x="760"  y="293" w="23"  h="35"                 pic="button-dual-alt"     />
-    <widget name="lfo2ToOsc2PWButton"         x="760"  y="355" w="23"  h="35"                 pic="button-dual-alt"     />
-    <widget name="lfo2ToVolumeButton"         x="760"  y="415" w="23"  h="35"                 pic="button-dual-alt"     />
+    <widget name="lfo2ToOsc1PWButton"         x="760"  y="293" w="23"  h="35"                 pic="button-dual-alt"         />
+    <widget name="lfo2ToOsc2PWButton"         x="760"  y="355" w="23"  h="35"                 pic="button-dual-alt"         />
+    <widget name="lfo2ToVolumeButton"         x="760"  y="415" w="23"  h="35"                 pic="button-dual-alt"         />
 
-    <!-- FILTER ENVELOPE                                                                                               -->
-    <widget name="filterEnvInvertButton"      x="833"  y="20" w="18"   h="13"                 pic="button-slim"         />
+    <!-- FILTER ENVELOPE                                                                                                   -->
+    <widget name="filterEnvInvertButton"      x="833"  y="20" w="18"   h="13"                 pic="button-slim"             />
 
-    <widget name="filterEnvAttackKnob"        x="850"  y="48"                  d="40"         pic="knob"                />
-    <widget name="filterEnvDecayKnob"         x="919"  y="48"                  d="40"         pic="knob"                />
-    <widget name="filterEnvSustainKnob"       x="988"  y="48"                  d="40"         pic="knob"                />
-    <widget name="filterEnvReleaseKnob"       x="1057" y="48"                  d="40"         pic="knob"                />
+    <widget name="filterEnvAttackKnob"        x="850"  y="48"                  d="40"         pic="knob"                    />
+    <widget name="filterEnvDecayKnob"         x="919"  y="48"                  d="40"         pic="knob"                    />
+    <widget name="filterEnvSustainKnob"       x="988"  y="48"                  d="40"         pic="knob"                    />
+    <widget name="filterEnvReleaseKnob"       x="1057" y="48"                  d="40"         pic="knob"                    />
 
-    <widget name="filterEnvAttackCurveSlider" x="844"  y="110" w="50"  h="13"         fh="13" pic="slider-h"            />
-    <widget name="velToFilterEnvSlider"       x="1052" y="110" w="50"  h="13"         fh="13" pic="slider-h"            />
+    <widget name="filterEnvAttackCurveSlider" x="844"  y="110" w="50"  h="13"         fh="13" pic="slider-h"                />
+    <widget name="velToFilterEnvSlider"       x="1052" y="110" w="50"  h="13"         fh="13" pic="slider-h"                />
 
-    <!-- AMPLIFIER ENVELOPE                                                                                            -->
-    <widget name="ampEnvAttackKnob"           x="850"  y="175"                 d="40"         pic="knob"                />
-    <widget name="ampEnvDecayKnob"            x="919"  y="175"                 d="40"         pic="knob"                />
-    <widget name="ampEnvSustainKnob"          x="988"  y="175"                 d="40"         pic="knob"                />
-    <widget name="ampEnvReleaseKnob"          x="1057" y="175"                 d="40"         pic="knob"                />
+    <!-- AMPLIFIER ENVELOPE                                                                                                -->
+    <widget name="ampEnvAttackKnob"           x="850"  y="175"                 d="40"         pic="knob"                    />
+    <widget name="ampEnvDecayKnob"            x="919"  y="175"                 d="40"         pic="knob"                    />
+    <widget name="ampEnvSustainKnob"          x="988"  y="175"                 d="40"         pic="knob"                    />
+    <widget name="ampEnvReleaseKnob"          x="1057" y="175"                 d="40"         pic="knob"                    />
 
-    <widget name="ampEnvAttackCurveSlider"    x="844"  y="237" w="50"  h="13"         fh="13" pic="slider-h"            />
-    <widget name="velToAmpEnvSlider"          x="1052" y="237" w="50"  h="13"         fh="13" pic="slider-h"            />
+    <widget name="ampEnvAttackCurveSlider"    x="844"  y="237" w="50"  h="13"         fh="13" pic="slider-h"                />
+    <widget name="velToAmpEnvSlider"          x="1052" y="237" w="50"  h="13"         fh="13" pic="slider-h"                />
 
-    <!-- VOICE VARIATION                                                                                               -->
-    <widget name="portamentoSlopKnob"         x="850"  y="291"                 d="40"         pic="knob"                />
-    <widget name="filterSlopKnob"             x="919"  y="291"                 d="40"         pic="knob"                />
-    <widget name="envelopeSlopKnob"           x="988"  y="291"                 d="40"         pic="knob"                />
-    <widget name="levelSlopKnob"              x="1057" y="291"                 d="40"         pic="knob"                />
+    <!-- VOICE VARIATION                                                                                                   -->
+    <widget name="portamentoSlopKnob"         x="850"  y="291"                 d="40"         pic="knob"                    />
+    <widget name="filterSlopKnob"             x="919"  y="291"                 d="40"         pic="knob"                    />
+    <widget name="envelopeSlopKnob"           x="988"  y="291"                 d="40"         pic="knob"                    />
+    <widget name="levelSlopKnob"              x="1057" y="291"                 d="40"         pic="knob"                    />
 
-    <widget name="pan1Knob"                   x="850"  y="353"                 d="40"         pic="knob"                />
-    <widget name="pan2Knob"                   x="919"  y="353"                 d="40"         pic="knob"                />
-    <widget name="pan3Knob"                   x="988"  y="353"                 d="40"         pic="knob"                />
-    <widget name="pan4Knob"                   x="1057" y="353"                 d="40"         pic="knob"                />
+    <widget name="pan1Knob"                   x="850"  y="353"                 d="40"         pic="knob"                    />
+    <widget name="pan2Knob"                   x="919"  y="353"                 d="40"         pic="knob"                    />
+    <widget name="pan3Knob"                   x="988"  y="353"                 d="40"         pic="knob"                    />
+    <widget name="pan4Knob"                   x="1057" y="353"                 d="40"         pic="knob"                    />
 
-    <widget name="pan5Knob"                   x="850"  y="413"                 d="40"         pic="knob"                />
-    <widget name="pan6Knob"                   x="919"  y="413"                 d="40"         pic="knob"                />
-    <widget name="pan7Knob"                   x="988"  y="413"                 d="40"         pic="knob"                />
-    <widget name="pan8Knob"                   x="1057" y="413"                 d="40"         pic="knob"                />
+    <widget name="pan5Knob"                   x="850"  y="413"                 d="40"         pic="knob"                    />
+    <widget name="pan6Knob"                   x="919"  y="413"                 d="40"         pic="knob"                    />
+    <widget name="pan7Knob"                   x="988"  y="413"                 d="40"         pic="knob"                    />
+    <widget name="pan8Knob"                   x="1057" y="413"                 d="40"         pic="knob"                    />
 
-    <widget name="voice1LED"                  x="895"  y="354" w="9"   h="9"                  pic="label-led1"          />
-    <widget name="voice2LED"                  x="964"  y="354" w="9"   h="9"                  pic="label-led1"          />
-    <widget name="voice3LED"                  x="1033" y="354" w="9"   h="9"                  pic="label-led1"          />
-    <widget name="voice4LED"                  x="1102" y="354" w="9"   h="9"                  pic="label-led1"          />
+    <widget name="voice1LED"                  x="895"  y="354" w="9"   h="9"                  pic="label-led1"              />
+    <widget name="voice2LED"                  x="964"  y="354" w="9"   h="9"                  pic="label-led1"              />
+    <widget name="voice3LED"                  x="1033" y="354" w="9"   h="9"                  pic="label-led1"              />
+    <widget name="voice4LED"                  x="1102" y="354" w="9"   h="9"                  pic="label-led1"              />
 
-    <widget name="voice5LED"                  x="895"  y="414" w="9"   h="9"                  pic="label-led1"          />
-    <widget name="voice6LED"                  x="964"  y="414" w="9"   h="9"                  pic="label-led1"          />
-    <widget name="voice7LED"                  x="1033" y="414" w="9"   h="9"                  pic="label-led1"          />
-    <widget name="voice8LED"                  x="1102" y="414" w="9"   h="9"                  pic="label-led1"          />
+    <widget name="voice5LED"                  x="895"  y="414" w="9"   h="9"                  pic="label-led1"              />
+    <widget name="voice6LED"                  x="964"  y="414" w="9"   h="9"                  pic="label-led1"              />
+    <widget name="voice7LED"                  x="1033" y="414" w="9"   h="9"                  pic="label-led1"              />
+    <widget name="voice8LED"                  x="1102" y="414" w="9"   h="9"                  pic="label-led1"              />
 
-    <widget name="voice9LED"                  x="895"  y="364" w="9"   h="9"                  pic="label-led2"          />
-    <widget name="voice10LED"                 x="964"  y="364" w="9"   h="9"                  pic="label-led2"          />
-    <widget name="voice11LED"                 x="1033" y="364" w="9"   h="9"                  pic="label-led2"          />
-    <widget name="voice12LED"                 x="1102" y="364" w="9"   h="9"                  pic="label-led2"          />
+    <widget name="voice9LED"                  x="895"  y="364" w="9"   h="9"                  pic="label-led2"              />
+    <widget name="voice10LED"                 x="964"  y="364" w="9"   h="9"                  pic="label-led2"              />
+    <widget name="voice11LED"                 x="1033" y="364" w="9"   h="9"                  pic="label-led2"              />
+    <widget name="voice12LED"                 x="1102" y="364" w="9"   h="9"                  pic="label-led2"              />
 
-    <widget name="voice13LED"                 x="895"  y="424" w="9"   h="9"                  pic="label-led2"          />
-    <widget name="voice14LED"                 x="964"  y="424" w="9"   h="9"                  pic="label-led2"          />
-    <widget name="voice15LED"                 x="1033" y="424" w="9"   h="9"                  pic="label-led2"          />
-    <widget name="voice16LED"                 x="1102" y="424" w="9"   h="9"                  pic="label-led2"          />
+    <widget name="voice13LED"                 x="895"  y="424" w="9"   h="9"                  pic="label-led2"              />
+    <widget name="voice14LED"                 x="964"  y="424" w="9"   h="9"                  pic="label-led2"              />
+    <widget name="voice15LED"                 x="1033" y="424" w="9"   h="9"                  pic="label-led2"              />
+    <widget name="voice16LED"                 x="1102" y="424" w="9"   h="9"                  pic="label-led2"              />
 
-    <widget name="voice17LED"                 x="895"  y="374" w="9"   h="9"                  pic="label-led3"          />
-    <widget name="voice18LED"                 x="964"  y="374" w="9"   h="9"                  pic="label-led3"          />
-    <widget name="voice19LED"                 x="1033" y="374" w="9"   h="9"                  pic="label-led3"          />
-    <widget name="voice20LED"                 x="1102" y="374" w="9"   h="9"                  pic="label-led3"          />
+    <widget name="voice17LED"                 x="895"  y="374" w="9"   h="9"                  pic="label-led3"              />
+    <widget name="voice18LED"                 x="964"  y="374" w="9"   h="9"                  pic="label-led3"              />
+    <widget name="voice19LED"                 x="1033" y="374" w="9"   h="9"                  pic="label-led3"              />
+    <widget name="voice20LED"                 x="1102" y="374" w="9"   h="9"                  pic="label-led3"              />
 
-    <widget name="voice21LED"                 x="895"  y="434" w="9"   h="9"                  pic="label-led3"          />
-    <widget name="voice22LED"                 x="964"  y="434" w="9"   h="9"                  pic="label-led3"          />
-    <widget name="voice23LED"                 x="1033" y="434" w="9"   h="9"                  pic="label-led3"          />
-    <widget name="voice24LED"                 x="1102" y="434" w="9"   h="9"                  pic="label-led3"          />
+    <widget name="voice21LED"                 x="895"  y="434" w="9"   h="9"                  pic="label-led3"              />
+    <widget name="voice22LED"                 x="964"  y="434" w="9"   h="9"                  pic="label-led3"              />
+    <widget name="voice23LED"                 x="1033" y="434" w="9"   h="9"                  pic="label-led3"              />
+    <widget name="voice24LED"                 x="1102" y="434" w="9"   h="9"                  pic="label-led3"              />
 
-    <widget name="voice25LED"                 x="895"  y="384" w="9"   h="9"                  pic="label-led4"          />
-    <widget name="voice26LED"                 x="964"  y="384" w="9"   h="9"                  pic="label-led4"          />
-    <widget name="voice27LED"                 x="1033" y="384" w="9"   h="9"                  pic="label-led4"          />
-    <widget name="voice28LED"                 x="1102" y="384" w="9"   h="9"                  pic="label-led4"          />
+    <widget name="voice25LED"                 x="895"  y="384" w="9"   h="9"                  pic="label-led4"              />
+    <widget name="voice26LED"                 x="964"  y="384" w="9"   h="9"                  pic="label-led4"              />
+    <widget name="voice27LED"                 x="1033" y="384" w="9"   h="9"                  pic="label-led4"              />
+    <widget name="voice28LED"                 x="1102" y="384" w="9"   h="9"                  pic="label-led4"              />
 
-    <widget name="voice29LED"                 x="895"  y="444" w="9"   h="9"                  pic="label-led4"          />
-    <widget name="voice30LED"                 x="964"  y="444" w="9"   h="9"                  pic="label-led4"          />
-    <widget name="voice31LED"                 x="1033" y="444" w="9"   h="9"                  pic="label-led4"          />
-    <widget name="voice32LED"                 x="1102" y="444" w="9"   h="9"                  pic="label-led4"          />
+    <widget name="voice29LED"                 x="895"  y="444" w="9"   h="9"                  pic="label-led4"              />
+    <widget name="voice30LED"                 x="964"  y="444" w="9"   h="9"                  pic="label-led4"              />
+    <widget name="voice31LED"                 x="1033" y="444" w="9"   h="9"                  pic="label-led4"              />
+    <widget name="voice32LED"                 x="1102" y="444" w="9"   h="9"                  pic="label-led4"              />
 
-    <!-- PROGRAMMER                                                                                                    -->
-    <widget name="patchNumberMenu"            x="56"   y="506" w="43"  h="31"                                           /> <!-- pic="menu-patch"  -->
+    <!-- PROGRAMMER                                                                                                        -->
+    <widget name="patchNumberMenu"            x="56"   y="506" w="43"  h="31"                                               /> <!-- pic="menu-patch"  -->
 
-    <widget name="patchNameLabel"             x="103"  y="506" w="166" h="31"                 color="FFFF0000"          /> <!-- color is AARRGGBB -->
+    <widget name="patchNameLabel"             x="103"  y="506" w="166" h="31"                 color="FFFF0000"              /> <!-- color is AARRGGBB -->
 
-    <widget name="prevPatchButton"            x="294"  y="504" w="23"  h="35"                 pic="button-clear"        />
-    <widget name="nextPatchButton"            x="327"  y="504" w="23"  h="35"                 pic="button-clear"        />
+    <widget name="prevPatchButton"            x="294"  y="504" w="23"  h="35"                 pic="button-clear"            />
+    <widget name="nextPatchButton"            x="327"  y="504" w="23"  h="35"                 pic="button-clear"            />
 
-    <widget name="savePatchButton"            x="372"  y="504" w="23"  h="35"                 pic="button-clear-red"    />
-    <widget name="undoPatchButton"            x="405"  y="504" w="23"  h="35"                 pic="button-clear"        />
+    <widget name="savePatchButton"            x="372"  y="504" w="23"  h="35"                 pic="button-clear-red"        />
+    <widget name="undoPatchButton"            x="405"  y="504" w="23"  h="35"                 pic="button-clear"            />
 
-    <widget name="initPatchButton"            x="450"  y="504" w="23"  h="35"                 pic="button-clear-white"  />
-    <widget name="randomizePatchButton"       x="483"  y="504" w="23"  h="35"                 pic="button-clear"        />
+    <widget name="initPatchButton"            x="450"  y="504" w="23"  h="35"                 pic="button-clear-white"      />
+    <widget name="randomizePatchButton"       x="483"  y="504" w="23"  h="35"                 pic="button-clear"            />
 
-    <widget name="groupSelectButton"          x="530"  y="504" w="23"  h="35"                 pic="button-alt"          />
+    <widget name="groupSelectButton"          x="530"  y="504" w="23"  h="35"                 pic="button-alt"              />
 
-    <!-- These buttons are ALWAYS using button-group-patch.png!                                                        -->
-    <widget name="select1Button"              x="578"  y="504" w="23"  h="35"                                           /> <!-- pic="button-group-patch" -->
-    <widget name="select2Button"              x="611"  y="504" w="23"  h="35"                                           /> <!-- pic="button-group-patch" -->
-    <widget name="select3Button"              x="644"  y="504" w="23"  h="35"                                           /> <!-- pic="button-group-patch" -->
-    <widget name="select4Button"              x="677"  y="504" w="23"  h="35"                                           /> <!-- pic="button-group-patch" -->
-    <widget name="select5Button"              x="710"  y="504" w="23"  h="35"                                           /> <!-- pic="button-group-patch" -->
-    <widget name="select6Button"              x="743"  y="504" w="23"  h="35"                                           /> <!-- pic="button-group-patch" -->
-    <widget name="select7Button"              x="776"  y="504" w="23"  h="35"                                           /> <!-- pic="button-group-patch" -->
-    <widget name="select8Button"              x="809"  y="504" w="23"  h="35"                                           /> <!-- pic="button-group-patch" -->
-    <widget name="select9Button"              x="842"  y="504" w="23"  h="35"                                           /> <!-- pic="button-group-patch" -->
-    <widget name="select10Button"             x="875"  y="504" w="23"  h="35"                                           /> <!-- pic="button-group-patch" -->
-    <widget name="select11Button"             x="908"  y="504" w="23"  h="35"                                           /> <!-- pic="button-group-patch" -->
-    <widget name="select12Button"             x="941"  y="504" w="23"  h="35"                                           /> <!-- pic="button-group-patch" -->
-    <widget name="select13Button"             x="974"  y="504" w="23"  h="35"                                           /> <!-- pic="button-group-patch" -->
-    <widget name="select14Button"             x="1007" y="504" w="23"  h="35"                                           /> <!-- pic="button-group-patch" -->
-    <widget name="select15Button"             x="1040" y="504" w="23"  h="35"                                           /> <!-- pic="button-group-patch" -->
-    <widget name="select16Button"             x="1073" y="504" w="23"  h="35"                                           /> <!-- pic="button-group-patch" -->
+    <!-- These buttons are ALWAYS using button-group-patch.png!                                                            -->
+    <widget name="select1Button"              x="578"  y="504" w="23"  h="35"                                               /> <!-- pic="button-group-patch" -->
+    <widget name="select2Button"              x="611"  y="504" w="23"  h="35"                                               /> <!-- pic="button-group-patch" -->
+    <widget name="select3Button"              x="644"  y="504" w="23"  h="35"                                               /> <!-- pic="button-group-patch" -->
+    <widget name="select4Button"              x="677"  y="504" w="23"  h="35"                                               /> <!-- pic="button-group-patch" -->
+    <widget name="select5Button"              x="710"  y="504" w="23"  h="35"                                               /> <!-- pic="button-group-patch" -->
+    <widget name="select6Button"              x="743"  y="504" w="23"  h="35"                                               /> <!-- pic="button-group-patch" -->
+    <widget name="select7Button"              x="776"  y="504" w="23"  h="35"                                               /> <!-- pic="button-group-patch" -->
+    <widget name="select8Button"              x="809"  y="504" w="23"  h="35"                                               /> <!-- pic="button-group-patch" -->
+    <widget name="select9Button"              x="842"  y="504" w="23"  h="35"                                               /> <!-- pic="button-group-patch" -->
+    <widget name="select10Button"             x="875"  y="504" w="23"  h="35"                                               /> <!-- pic="button-group-patch" -->
+    <widget name="select11Button"             x="908"  y="504" w="23"  h="35"                                               /> <!-- pic="button-group-patch" -->
+    <widget name="select12Button"             x="941"  y="504" w="23"  h="35"                                               /> <!-- pic="button-group-patch" -->
+    <widget name="select13Button"             x="974"  y="504" w="23"  h="35"                                               /> <!-- pic="button-group-patch" -->
+    <widget name="select14Button"             x="1007" y="504" w="23"  h="35"                                               /> <!-- pic="button-group-patch" -->
+    <widget name="select15Button"             x="1040" y="504" w="23"  h="35"                                               /> <!-- pic="button-group-patch" -->
+    <widget name="select16Button"             x="1073" y="504" w="23"  h="35"                                               /> <!-- pic="button-group-patch" -->
 
-    <!-- SAVE PATCH DIALOG                                                                                             -->
-    <widget name="savePatchDialog"                             w="246" h="328"                                          /> <!-- pic="label-bg-save-patch" -->
-    <widget name="savePatchNameLabel"         x="22"   y="29"  w="200" h="31"                 color="FFFF0000"          /> <!-- color is AARRGGBB         -->
-    <widget name="savePatchAuthorLabel"       x="22"   y="90"  w="200" h="31"                 color="FFFF0000"          /> <!-- color is AARRGGBB         -->
-    <widget name="savePatchProjectLabel"      x="22"   y="151" w="200" h="31"                 color="FFFF0000"          /> <!-- color is AARRGGBB         -->
-    <widget name="savePatchCategoryMenu"      x="25"   y="212" w="90"  h="31"                                           /> <!-- pic="menu-categories"     -->
-    <widget name="savePatchLicenseLabel"      x="126"  y="212" w="96"  h="31"                 color="FFFF0000"          /> <!-- color is AARRGGBB         -->
-    <widget name="savePatchOKButton"          x="92"   y="272" w="23"  h="35"                                           /> <!-- pic="button-clear-red"    -->
-    <widget name="savePatchCancelButton"      x="129"  y="272" w="23"  h="35"                                           /> <!-- pic="button-clear-white"  -->
+    <!-- SAVE PATCH DIALOG                                                                                                 -->
+    <widget name="savePatchDialog"                             w="246" h="328"                                              /> <!-- pic="label-bg-save-patch" -->
+    <widget name="savePatchNameLabel"         x="22"   y="29"  w="200" h="31"                 color="FFFF0000"              /> <!-- color is AARRGGBB         -->
+    <widget name="savePatchAuthorLabel"       x="22"   y="90"  w="200" h="31"                 color="FFFF0000"              /> <!-- color is AARRGGBB         -->
+    <widget name="savePatchProjectLabel"      x="22"   y="151" w="200" h="31"                 color="FFFF0000"              /> <!-- color is AARRGGBB         -->
+    <widget name="savePatchCategoryMenu"      x="25"   y="212" w="90"  h="31"                                               /> <!-- pic="menu-categories"     -->
+    <widget name="savePatchLicenseLabel"      x="126"  y="212" w="96"  h="31"                 color="FFFF0000"              /> <!-- color is AARRGGBB         -->
+    <widget name="savePatchOKButton"          x="92"   y="272" w="23"  h="35"                                               /> <!-- pic="button-clear-red"    -->
+    <widget name="savePatchCancelButton"      x="129"  y="272" w="23"  h="35"                                               /> <!-- pic="button-clear-white"  -->
 </obxf-theme>

--- a/src/PluginEditor.cpp
+++ b/src/PluginEditor.cpp
@@ -85,15 +85,15 @@ ObxfAudioProcessorEditor::knobRegistry()
         {"velToAmpEnvSlider",        {ID::VelToAmpEnv,           Name::VelToAmpEnv,            0.f,  "slider-h"}},
 
         // ---- OSCILLATORS ----
-        {"osc1PitchKnob",            {ID::Osc1Pitch,             Name::Osc1Pitch,             0.5f,  "knob", -1, false, pitchSnapCallbacks}},
-        {"osc2PitchKnob",            {ID::Osc2Pitch,             Name::Osc2Pitch,             0.5f,  "knob", -1, false, pitchSnapCallbacks}},
+        {"osc1PitchKnob",            {ID::Osc1Pitch,             Name::Osc1Pitch,             0.5f,  "knob", pitchSnapCallbacks}},
+        {"osc2PitchKnob",            {ID::Osc2Pitch,             Name::Osc2Pitch,             0.5f,  "knob", pitchSnapCallbacks}},
         {"osc2DetuneKnob",           {ID::Osc2Detune,            Name::Osc2Detune,             0.f,  "knob"}},
         {"oscPWKnob",                {ID::OscPW,                 Name::OscPW,                  0.f,  "knob"}},
         {"osc2PWOffsetKnob",         {ID::Osc2PWOffset,          Name::Osc2PWOffset,           0.f,  "knob"}},
         {"oscCrossmodKnob",          {ID::OscCrossmod,           Name::OscCrossmod,            0.f,  "knob"}},
         {"oscBrightnessKnob",        {ID::OscBrightness,         Name::OscBrightness,          1.f,  "knob"}},
 
-        {"envToPitchAmountKnob",     {ID::EnvToPitchAmount, Name::EnvToPitchAmount, 0.f, "knob", -1, false,
+        {"envToPitchAmountKnob",     {ID::EnvToPitchAmount, Name::EnvToPitchAmount, 0.f, "knob",
             [](Knob *k) {
                 k->cmdDragCallback = [](const double value) {
                     const auto semitoneValue = static_cast<int>(juce::jmap(value, 0.0, 36.0));
@@ -117,7 +117,7 @@ ObxfAudioProcessorEditor::knobRegistry()
         // ---- MASTER ----
         {"volumeKnob",               {ID::Volume,                Name::Volume,                 0.5f, "knob"}},
         {"tuneKnob",                 {ID::Tune,                  Name::Tune,                   0.5f, "knob"}},
-        {"transposeKnob",            {ID::Transpose,             Name::Transpose,              0.5f, "knob", -1, false,
+        {"transposeKnob",            {ID::Transpose,             Name::Transpose,              0.5f, "knob",
             [](Knob *k) {
                 k->altDragCallback = [](const double value) {
                     const auto octValue = static_cast<int>(juce::jmap(value, -2.0, 2.0));
@@ -126,8 +126,8 @@ ObxfAudioProcessorEditor::knobRegistry()
             }}},
 
         // ---- GLOBAL ----
-        {"portamentoKnob",           {ID::Portamento,            Name::Portamento,             0.f,  "knob", -1, true}},
-        {"unisonDetuneKnob",         {ID::UnisonDetune,          Name::UnisonDetune,           0.25f,"knob", -1, true}},
+        {"portamentoKnob",           {ID::Portamento,            Name::Portamento,             0.f,  "knob"}},
+        {"unisonDetuneKnob",         {ID::UnisonDetune,          Name::UnisonDetune,           0.25f,"knob"}},
 
         // ---- CONTROL ----
         {"vibratoRateKnob",          {ID::VibratoRate,           Name::VibratoRate,            0.3f, "knob"}},
@@ -139,22 +139,22 @@ ObxfAudioProcessorEditor::knobRegistry()
         {"levelSlopKnob",            {ID::LevelSlop,             Name::LevelSlop,              0.25f,"knob"}},
 
         // ---- LFO 1 ----
-        {"lfo1RateKnob",             {ID::LFO1Rate,              Name::LFO1Rate,               0.5f, "knob", 0}},
-        {"lfo1ModAmount1Knob",       {ID::LFO1ModAmount1,        Name::LFO1ModAmount1,         0.f,  "knob", 0}},
-        {"lfo1ModAmount2Knob",       {ID::LFO1ModAmount2,        Name::LFO1ModAmount2,         0.f,  "knob", 0}},
-        {"lfo1Wave1Knob",            {ID::LFO1Wave1,             Name::LFO1Wave1,              0.5f, "knob", 0}},
-        {"lfo1Wave2Knob",            {ID::LFO1Wave2,             Name::LFO1Wave2,              0.5f, "knob", 0}},
-        {"lfo1Wave3Knob",            {ID::LFO1Wave3,             Name::LFO1Wave3,              0.5f, "knob", 0}},
-        {"lfo1PWSlider",             {ID::LFO1PW,                Name::LFO1PW,                 0.f,  "knob", 0}},
+        {"lfo1RateKnob",             {ID::LFO1Rate,              Name::LFO1Rate,               0.5f, "knob"}},
+        {"lfo1ModAmount1Knob",       {ID::LFO1ModAmount1,        Name::LFO1ModAmount1,         0.f,  "knob"}},
+        {"lfo1ModAmount2Knob",       {ID::LFO1ModAmount2,        Name::LFO1ModAmount2,         0.f,  "knob"}},
+        {"lfo1Wave1Knob",            {ID::LFO1Wave1,             Name::LFO1Wave1,              0.5f, "knob"}},
+        {"lfo1Wave2Knob",            {ID::LFO1Wave2,             Name::LFO1Wave2,              0.5f, "knob"}},
+        {"lfo1Wave3Knob",            {ID::LFO1Wave3,             Name::LFO1Wave3,              0.5f, "knob"}},
+        {"lfo1PWSlider",             {ID::LFO1PW,                Name::LFO1PW,                 0.f,  "knob"}},
 
         // ---- LFO 2 ----
-        {"lfo2RateKnob",             {ID::LFO2Rate,              Name::LFO2Rate,               0.5f, "knob", 1}},
-        {"lfo2ModAmount1Knob",       {ID::LFO2ModAmount1,        Name::LFO2ModAmount1,         0.f,  "knob", 1}},
-        {"lfo2ModAmount2Knob",       {ID::LFO2ModAmount2,        Name::LFO2ModAmount2,         0.f,  "knob", 1}},
-        {"lfo2Wave1Knob",            {ID::LFO2Wave1,             Name::LFO2Wave1,              0.5f, "knob", 1}},
-        {"lfo2Wave2Knob",            {ID::LFO2Wave2,             Name::LFO2Wave2,              0.5f, "knob", 1}},
-        {"lfo2Wave3Knob",            {ID::LFO2Wave3,             Name::LFO2Wave3,              0.5f, "knob", 1}},
-        {"lfo2PWSlider",             {ID::LFO2PW,                Name::LFO2PW,                 0.f,  "knob", 1}},
+        {"lfo2RateKnob",             {ID::LFO2Rate,              Name::LFO2Rate,               0.5f, "knob"}},
+        {"lfo2ModAmount1Knob",       {ID::LFO2ModAmount1,        Name::LFO2ModAmount1,         0.f,  "knob"}},
+        {"lfo2ModAmount2Knob",       {ID::LFO2ModAmount2,        Name::LFO2ModAmount2,         0.f,  "knob"}},
+        {"lfo2Wave1Knob",            {ID::LFO2Wave1,             Name::LFO2Wave1,              0.5f, "knob"}},
+        {"lfo2Wave2Knob",            {ID::LFO2Wave2,             Name::LFO2Wave2,              0.5f, "knob"}},
+        {"lfo2Wave3Knob",            {ID::LFO2Wave3,             Name::LFO2Wave3,              0.5f, "knob"}},
+        {"lfo2PWSlider",             {ID::LFO2PW,                Name::LFO2PW,                 0.f,  "knob"}},
     };
     // clang-format on
 
@@ -188,18 +188,18 @@ ObxfAudioProcessorEditor::buttonRegistry()
         {"filterEnvInvertButton",    {ID::FilterEnvInvert,       Name::FilterEnvInvert,       "button-slim"}},
 
         // ---- GLOBAL ----
-        {"unisonButton",             {ID::Unison,                Name::Unison,                "button",      -1, true}},
-        {"hqModeButton",             {ID::HQMode,                Name::HQMode,                "button",      -1, true}},
+        {"unisonButton",             {ID::Unison,                Name::Unison,                "button"}},
+        {"hqModeButton",             {ID::HQMode,                Name::HQMode,                "button"}},
         {"bendOsc2OnlyButton",       {ID::BendOsc2Only,          Name::BendOsc2Only,          "button"}},
 
         // ---- CONTROL ----
         {"vibratoWaveButton",        {ID::VibratoWave,           Name::VibratoWave,           "button-slim-vibrato-wave"}},
 
         // ---- LFO 1 ----
-        {"lfo1TempoSyncButton",      {ID::LFO1TempoSync,         Name::LFO1TempoSync,         "button-slim",     0}},
+        {"lfo1TempoSyncButton",      {ID::LFO1TempoSync,         Name::LFO1TempoSync,         "button-slim"}},
 
         // ---- LFO 2 ----
-        {"lfo2TempoSyncButton",      {ID::LFO2TempoSync,         Name::LFO2TempoSync,         "button-slim-alt", 1}},
+        {"lfo2TempoSyncButton",      {ID::LFO2TempoSync,         Name::LFO2TempoSync,         "button-slim-alt"}},
     };
     // clang-format on
 
@@ -216,20 +216,20 @@ ObxfAudioProcessorEditor::multiStateRegistry()
         {"noiseColorButton",         {ID::NoiseColor,            Name::NoiseColor,            "button-slim-noise",  3}},
 
         // ---- LFO 1 routing ----
-        {"lfo1ToOsc1PitchButton",    {ID::LFO1ToOsc1Pitch,       Name::LFO1ToOsc1Pitch,       "button-dual",     3, 0}},
-        {"lfo1ToOsc2PitchButton",    {ID::LFO1ToOsc2Pitch,       Name::LFO1ToOsc2Pitch,       "button-dual",     3, 0}},
-        {"lfo1ToFilterCutoffButton", {ID::LFO1ToFilterCutoff,    Name::LFO1ToFilterCutoff,    "button-dual",     3, 0}},
-        {"lfo1ToOsc1PWButton",       {ID::LFO1ToOsc1PW,          Name::LFO1ToOsc1PW,          "button-dual",     3, 0}},
-        {"lfo1ToOsc2PWButton",       {ID::LFO1ToOsc2PW,          Name::LFO1ToOsc2PW,          "button-dual",     3, 0}},
-        {"lfo1ToVolumeButton",       {ID::LFO1ToVolume,          Name::LFO1ToVolume,          "button-dual",     3, 0}},
+        {"lfo1ToOsc1PitchButton",    {ID::LFO1ToOsc1Pitch,       Name::LFO1ToOsc1Pitch,       "button-dual",     3}},
+        {"lfo1ToOsc2PitchButton",    {ID::LFO1ToOsc2Pitch,       Name::LFO1ToOsc2Pitch,       "button-dual",     3}},
+        {"lfo1ToFilterCutoffButton", {ID::LFO1ToFilterCutoff,    Name::LFO1ToFilterCutoff,    "button-dual",     3}},
+        {"lfo1ToOsc1PWButton",       {ID::LFO1ToOsc1PW,          Name::LFO1ToOsc1PW,          "button-dual",     3}},
+        {"lfo1ToOsc2PWButton",       {ID::LFO1ToOsc2PW,          Name::LFO1ToOsc2PW,          "button-dual",     3}},
+        {"lfo1ToVolumeButton",       {ID::LFO1ToVolume,          Name::LFO1ToVolume,          "button-dual",     3}},
 
         // ---- LFO 2 routing ----
-        {"lfo2ToOsc1PitchButton",    {ID::LFO2ToOsc1Pitch,       Name::LFO2ToOsc1Pitch,       "button-dual-alt", 3, 1}},
-        {"lfo2ToOsc2PitchButton",    {ID::LFO2ToOsc2Pitch,       Name::LFO2ToOsc2Pitch,       "button-dual-alt", 3, 1}},
-        {"lfo2ToFilterCutoffButton", {ID::LFO2ToFilterCutoff,    Name::LFO2ToFilterCutoff,    "button-dual-alt", 3, 1}},
-        {"lfo2ToOsc1PWButton",       {ID::LFO2ToOsc1PW,          Name::LFO2ToOsc1PW,          "button-dual-alt", 3, 1}},
-        {"lfo2ToOsc2PWButton",       {ID::LFO2ToOsc2PW,          Name::LFO2ToOsc2PW,          "button-dual-alt", 3, 1}},
-        {"lfo2ToVolumeButton",       {ID::LFO2ToVolume,          Name::LFO2ToVolume,          "button-dual-alt", 3, 1}},
+        {"lfo2ToOsc1PitchButton",    {ID::LFO2ToOsc1Pitch,       Name::LFO2ToOsc1Pitch,       "button-dual-alt", 3}},
+        {"lfo2ToOsc2PitchButton",    {ID::LFO2ToOsc2Pitch,       Name::LFO2ToOsc2Pitch,       "button-dual-alt", 3}},
+        {"lfo2ToFilterCutoffButton", {ID::LFO2ToFilterCutoff,    Name::LFO2ToFilterCutoff,    "button-dual-alt", 3}},
+        {"lfo2ToOsc1PWButton",       {ID::LFO2ToOsc1PW,          Name::LFO2ToOsc1PW,          "button-dual-alt", 3}},
+        {"lfo2ToOsc2PWButton",       {ID::LFO2ToOsc2PW,          Name::LFO2ToOsc2PW,          "button-dual-alt", 3}},
+        {"lfo2ToVolumeButton",       {ID::LFO2ToVolume,          Name::LFO2ToVolume,          "button-dual-alt", 3}},
     };
     // clang-format on
 
@@ -243,17 +243,172 @@ ObxfAudioProcessorEditor::listRegistry()
 
     // clang-format off
     static const std::unordered_map<std::string, ListDescriptor> reg = {
-        {"polyphonyMenu",        {ID::Polyphony,          Name::Polyphony,          "menu-poly",         true}},
-        {"unisonVoicesMenu",     {ID::UnisonVoices,       Name::UnisonVoices,       "menu-poly",         true}},
-        {"envLegatoModeMenu",    {ID::EnvLegatoMode,      Name::EnvLegatoMode,      "menu-legato",       true}},
-        {"notePriorityMenu",     {ID::NotePriority,       Name::NotePriority,       "menu-note-priority",true}},
-        {"bendUpRangeMenu",      {ID::BendUpRange,        Name::BendUpRange,        "menu-pitch-bend",   false}},
-        {"bendDownRangeMenu",    {ID::BendDownRange,      Name::BendDownRange,      "menu-pitch-bend",   false}},
-        {"filterXpanderModeMenu",{ID::FilterXpanderMode,  Name::FilterXpanderMode,  "menu-xpander",      false}},
+        {"polyphonyMenu",        {ID::Polyphony,          Name::Polyphony,          "menu-poly"         }},
+        {"unisonVoicesMenu",     {ID::UnisonVoices,       Name::UnisonVoices,       "menu-poly"         }},
+        {"envLegatoModeMenu",    {ID::EnvLegatoMode,      Name::EnvLegatoMode,      "menu-legato"       }},
+        {"notePriorityMenu",     {ID::NotePriority,       Name::NotePriority,       "menu-note-priority"}},
+        {"bendUpRangeMenu",      {ID::BendUpRange,        Name::BendUpRange,        "menu-pitch-bend"   }},
+        {"bendDownRangeMenu",    {ID::BendDownRange,      Name::BendDownRange,      "menu-pitch-bend"   }},
+        {"filterXpanderModeMenu",{ID::FilterXpanderMode,  Name::FilterXpanderMode,  "menu-xpander"      }},
     };
     // clang-format on
 
     return reg;
+}
+
+std::map<std::string, ObxfAudioProcessorEditor::PanelGroup>
+ObxfAudioProcessorEditor::panelGroupDefinitions()
+{
+    auto makePanel = [](std::string selector, std::vector<std::string> names,
+                        std::unique_ptr<PanelGroup> child = nullptr) -> Panel {
+        Panel p;
+        p.selectorButtonName = std::move(selector);
+        p.widgetNames = std::move(names);
+        p.childGroup = std::move(child);
+        return p;
+    };
+
+    // clang-format off
+    std::map<std::string, PanelGroup> m;
+
+    // ---- GLOBAL / MPE ----
+    {
+        auto &g = m["global"];
+
+        g.panels.push_back(
+            makePanel("globalSelectButton",
+            {
+                "portamentoKnob", "unisonDetuneKnob", "unisonButton",
+                "unisonVoicesMenu", "hqModeButton", "lockHQButton",
+                "polyphonyMenu", "envLegatoModeMenu", "notePriorityMenu",
+                "globalBGLabel",
+            }));
+
+        auto mpeSubGroup = std::make_unique<PanelGroup>();
+
+        mpeSubGroup->panels.push_back(
+            makePanel("mpeStrikeSelectButton",
+            {
+                "mpeStrikeDestination1Menu", "mpeStrikeAmount1Knob",
+                "mpeStrikeDestination2Menu", "mpeStrikeAmount2Knob",
+            }));
+        mpeSubGroup->panels.push_back(
+            makePanel("mpeLiftSelectButton",
+            {
+            "mpeLiftDestination1Menu",   "mpeLiftAmount1Knob",
+            "mpeLiftDestination2Menu",   "mpeLiftAmount2Knob",
+            }));
+        mpeSubGroup->panels.push_back(
+            makePanel("mpePressSelectButton",
+            {
+                "mpePressDestination1Menu",  "mpePressAmount1Knob",
+                "mpePressDestination2Menu",  "mpePressAmount2Knob",
+            }));
+        mpeSubGroup->panels.push_back(
+            makePanel("mpeSlideSelectButton",
+            {
+                "mpeSlideDestination1Menu",  "mpeSlideAmount1Knob",
+                "mpeSlideDestination2Menu",  "mpeSlideAmount2Knob",
+            }));
+
+        g.panels.push_back(
+            makePanel("mpeSelectButton",
+            {
+                "mpeLinesLabel", "mpeSlideBipolarButton", "mpeGlideRangeMenu",
+            },
+            std::move(mpeSubGroup)));
+    }
+
+    // ---- LFO ----
+    {
+        auto &g = m["lfo"];
+        g.panels.push_back(makePanel("lfo1SelectButton", {
+            "lfo1RateKnob", "lfo1ModAmount1Knob", "lfo1ModAmount2Knob",
+            "lfo1Wave1Knob", "lfo1Wave2Knob", "lfo1Wave3Knob", "lfo1PWSlider",
+            "lfo1TempoSyncButton",
+            "lfo1ToOsc1PitchButton", "lfo1ToOsc2PitchButton",
+            "lfo1ToFilterCutoffButton", "lfo1ToOsc1PWButton",
+            "lfo1ToOsc2PWButton", "lfo1ToVolumeButton",
+            "lfo1Wave2Label",
+        }));
+        g.panels.push_back(makePanel("lfo2SelectButton", {
+            "lfo2RateKnob", "lfo2ModAmount1Knob", "lfo2ModAmount2Knob",
+            "lfo2Wave1Knob", "lfo2Wave2Knob", "lfo2Wave3Knob", "lfo2PWSlider",
+            "lfo2TempoSyncButton",
+            "lfo2ToOsc1PitchButton", "lfo2ToOsc2PitchButton",
+            "lfo2ToFilterCutoffButton", "lfo2ToOsc1PWButton",
+            "lfo2ToOsc2PWButton", "lfo2ToVolumeButton",
+            "lfo2Wave2Label",
+        }));
+    }
+
+    // clang-format on
+    return m;
+}
+
+void ObxfAudioProcessorEditor::PanelGroup::resolve(
+    const std::map<juce::String, std::unique_ptr<juce::Component>> &componentMap)
+{
+    for (auto &panel : panels)
+    {
+        panel.resolvedWidgets.clear();
+
+        for (auto &name : panel.widgetNames)
+        {
+            if (auto it = componentMap.find(name); it != componentMap.end() && it->second)
+            {
+                panel.resolvedWidgets.push_back(it->second.get());
+            }
+        }
+
+        if (panel.childGroup)
+        {
+            panel.childGroup->resolve(componentMap);
+        }
+    }
+}
+
+void ObxfAudioProcessorEditor::PanelGroup::showPanel(int index)
+{
+    activePanel = index;
+
+    for (int i = 0; i < (int)panels.size(); i++)
+    {
+        const bool visible = (i == index);
+
+        for (auto *c : panels[i].resolvedWidgets)
+        {
+            c->setVisible(visible);
+        }
+
+        if (panels[i].childGroup)
+        {
+            if (visible)
+            {
+                panels[i].childGroup->showPanel(panels[i].childGroup->activePanel);
+            }
+            else
+            {
+                panels[i].childGroup->hideAll();
+            }
+        }
+    }
+}
+
+void ObxfAudioProcessorEditor::PanelGroup::hideAll()
+{
+    for (auto &panel : panels)
+    {
+        for (auto *c : panel.resolvedWidgets)
+        {
+            c->setVisible(false);
+        }
+
+        if (panel.childGroup)
+        {
+            panel.childGroup->hideAll();
+        }
+    }
 }
 
 template <typename T>
@@ -792,62 +947,6 @@ void ObxfAudioProcessorEditor::idle()
         if (filterOptionsLabel && (int)fourPole != filterOptionsLabel->getCurrentFrame())
         {
             filterOptionsLabel->setCurrentFrame(fourPole);
-
-            if (auto *mlb = getWidget<ToggleButton>("midiLearnButton");
-                mlb && mlb->getToggleState())
-            {
-                enterMidiLearnMode();
-            }
-        }
-
-        if (auto *b = getWidget<ToggleButton>("filter2PoleBPBlendButton"))
-        {
-            if (b->isVisible() != !fourPole)
-            {
-                b->setVisible(!fourPole);
-            }
-        }
-
-        if (auto *b = getWidget<ToggleButton>("filter2PolePushButton"))
-        {
-            if (b->isVisible() != !fourPole)
-            {
-                b->setVisible(!fourPole);
-            }
-        }
-
-        if (auto *b = getWidget<ToggleButton>("filter4PoleXpanderButton"))
-        {
-            if (b->isVisible() != fourPole)
-            {
-                b->setVisible(fourPole);
-
-                if (auto *mlb = getWidget<ToggleButton>("midiLearnButton");
-                    mlb && mlb->getToggleState())
-                {
-                    enterMidiLearnMode();
-                }
-            }
-        }
-
-        if (auto *filterModeKnob = getWidget<Knob>("filterModeKnob"))
-        {
-            const bool state = !(fourPole && xpanderMode);
-
-            if (filterModeKnob->isVisible() != state)
-            {
-                filterModeKnob->setVisible(state);
-            }
-        }
-
-        if (auto *filterXpanderModeMenu = getWidget<ButtonList>("filterXpanderModeMenu"))
-        {
-            const bool state = fourPole && xpanderMode;
-
-            if (filterXpanderModeMenu->isVisible() != state)
-            {
-                filterXpanderModeMenu->setVisible(state);
-            }
         }
     }
 
@@ -1148,6 +1247,7 @@ void ObxfAudioProcessorEditor::clearAndResetComponents(ObxfAudioProcessor &owner
     popupMenus.clear();
     cachedLayout.clear();
     componentByParamID.clear();
+    panelGroups.clear();
 
     // Remove all child components that are in componentMap before clearing it
     for (auto &[name, comp] : componentMap)
@@ -1161,19 +1261,8 @@ void ObxfAudioProcessorEditor::clearAndResetComponents(ObxfAudioProcessor &owner
     componentMap.clear();
 
     ownerFilter.removeChangeListener(this);
+
     themeLocation = utils.getCurrentThemeLocation();
-    globalControls.clear();
-    mpeControls.clear();
-
-    for (auto &controls : lfoControls)
-    {
-        controls.clear();
-    }
-
-    for (auto &controls : mpeMatrixControls)
-    {
-        controls.clear();
-    }
 }
 
 bool ObxfAudioProcessorEditor::parseAndCreateComponentsFromTheme()
@@ -1215,6 +1304,87 @@ void ObxfAudioProcessorEditor::createComponentsFromXml(const juce::XmlElement *d
     createSpecialWidgets(doc);
     cacheLayoutFromXml(doc);
 
+    panelGroups = panelGroupDefinitions();
+
+    for (auto &[name, group] : panelGroups)
+    {
+        group.resolve(componentMap);
+        group.showPanel(group.activePanel);
+    }
+
+    auto switchPanel = [this](PanelGroup &group, int index, std::function<void()> existingClickCb) {
+        group.showPanel(index);
+
+        if (existingClickCb)
+        {
+            existingClickCb();
+        }
+
+        if (auto *mlb = getWidget<ToggleButton>("midiLearnButton"); mlb && mlb->getToggleState())
+        {
+            enterMidiLearnMode();
+        }
+    };
+
+    auto updateFilterVisibility = [this](std::function<void()> existingClickCb = nullptr) {
+        const bool fourPole = getWidget<ToggleButton>("filter4PoleModeButton") &&
+                              getWidget<ToggleButton>("filter4PoleModeButton")->getToggleState();
+        const bool xpander = getWidget<ToggleButton>("filter4PoleXpanderButton") &&
+                             getWidget<ToggleButton>("filter4PoleXpanderButton")->getToggleState();
+
+        if (existingClickCb)
+        {
+            existingClickCb();
+        }
+
+        if (auto *b = getWidget<ToggleButton>("filter2PoleBPBlendButton"))
+            b->setVisible(!fourPole);
+        if (auto *b = getWidget<ToggleButton>("filter2PolePushButton"))
+            b->setVisible(!fourPole);
+        if (auto *b = getWidget<ToggleButton>("filter4PoleXpanderButton"))
+            b->setVisible(fourPole);
+        if (auto *k = getWidget<Knob>("filterModeKnob"))
+            k->setVisible(!(fourPole && xpander));
+        if (auto *m = getWidget<ButtonList>("filterXpanderModeMenu"))
+            m->setVisible(fourPole && xpander);
+    };
+
+    for (auto &[groupName, group] : panelGroups)
+    {
+        for (int i = 0; i < (int)group.panels.size(); i++)
+        {
+            if (auto *b = getWidget<ToggleButton>(group.panels[i].selectorButtonName))
+            {
+                auto existingClickCb = b->onClick;
+
+                if (b->getRadioGroupId() != 0)
+                    b->onClick = [&group, i, existingClickCb, switchPanel]() {
+                        switchPanel(group, i, existingClickCb);
+                    };
+                else
+                    b->onClick = [&group, b, existingClickCb, switchPanel]() {
+                        switchPanel(group, b->getToggleState() ? 1 : 0, existingClickCb);
+                    };
+            }
+        }
+    }
+
+    if (auto *b = getWidget<ToggleButton>("filter4PoleModeButton"))
+    {
+        auto existingClickCb = b->onClick;
+        b->onClick = [existingClickCb, updateFilterVisibility]() {
+            updateFilterVisibility(existingClickCb);
+        };
+    }
+
+    if (auto *b = getWidget<ToggleButton>("filter4PoleXpanderButton"))
+    {
+        auto existingClickCb = b->onClick;
+        b->onClick = [existingClickCb, updateFilterVisibility]() {
+            updateFilterVisibility(existingClickCb);
+        };
+    }
+
     componentByParamID.clear();
 
     for (auto &[n, c] : componentMap)
@@ -1227,6 +1397,8 @@ void ObxfAudioProcessorEditor::createComponentsFromXml(const juce::XmlElement *d
             }
         }
     }
+
+    updateFilterVisibility();
 }
 
 void ObxfAudioProcessorEditor::createParameterBoundWidgets(const juce::XmlElement *doc)
@@ -1264,17 +1436,7 @@ void ObxfAudioProcessorEditor::createParameterBoundWidgets(const juce::XmlElemen
                 desc.postCreate(knob.get());
             }
 
-            auto *raw = storeWidget(componentMap, this, name, std::move(knob));
-
-            if (desc.lfoGroup >= 0 && desc.lfoGroup < (int)lfoControls.size())
-            {
-                lfoControls[desc.lfoGroup].push_back(raw);
-            }
-
-            if (desc.isGlobalControl)
-            {
-                globalControls.push_back(raw);
-            }
+            storeWidget(componentMap, this, name, std::move(knob));
 
             continue;
         }
@@ -1296,17 +1458,7 @@ void ObxfAudioProcessorEditor::createParameterBoundWidgets(const juce::XmlElemen
                 desc.postCreate(button.get());
             }
 
-            auto *raw = storeWidget(componentMap, this, name, std::move(button));
-
-            if (desc.lfoGroup >= 0 && desc.lfoGroup < (int)lfoControls.size())
-            {
-                lfoControls[desc.lfoGroup].push_back(raw);
-            }
-
-            if (desc.isGlobalControl)
-            {
-                globalControls.push_back(raw);
-            }
+            storeWidget(componentMap, this, name, std::move(button));
 
             continue;
         }
@@ -1322,12 +1474,7 @@ void ObxfAudioProcessorEditor::createParameterBoundWidgets(const juce::XmlElemen
                 continue;
             }
 
-            auto *raw = storeWidget(componentMap, this, name, std::move(btn));
-
-            if (desc.lfoGroup >= 0 && desc.lfoGroup < (int)lfoControls.size())
-            {
-                lfoControls[desc.lfoGroup].push_back(raw);
-            }
+            storeWidget(componentMap, this, name, std::move(btn));
 
             continue;
         }
@@ -1343,12 +1490,7 @@ void ObxfAudioProcessorEditor::createParameterBoundWidgets(const juce::XmlElemen
                 continue;
             }
 
-            auto *raw = storeWidget(componentMap, this, name, std::move(list));
-
-            if (desc.isGlobalControl)
-            {
-                globalControls.push_back(raw);
-            }
+            storeWidget(componentMap, this, name, std::move(list));
 
             continue;
         }
@@ -1494,20 +1636,6 @@ void ObxfAudioProcessorEditor::createSpecialWidgets(const juce::XmlElement *doc)
                 {
                     raw->setInterceptsMouseClicks(false, false);
                 }
-
-                if (def.isMPE)
-                {
-                    mpeControls.push_back(raw);
-                }
-
-                if (name == "lfo1Wave2Label")
-                {
-                    lfoControls[0].push_back(raw);
-                }
-                if (name == "lfo2Wave2Label")
-                {
-                    lfoControls[1].push_back(raw);
-                }
             }
 
             handled = true;
@@ -1587,8 +1715,6 @@ void ObxfAudioProcessorEditor::createSpecialWidgets(const juce::XmlElement *doc)
                                  useAssetOrDefault(pic, "button-lock"));
             auto *raw = storeWidget(componentMap, this, name, std::move(btn));
             auto *tb = static_cast<ToggleButton *>(raw);
-
-            globalControls.push_back(raw);
 
             tb->setToggleState(processor.lockHighQuality.load(), juce::dontSendNotification);
 
@@ -1812,29 +1938,7 @@ void ObxfAudioProcessorEditor::createSpecialWidgets(const juce::XmlElement *doc)
 
             tb->setRadioGroupId(1);
 
-            tb->onClick = [this, whichIdx]() {
-                processor.selectedLFOIndex = whichIdx;
-
-                for (int i = 0; i < NUM_LFOS; i++)
-                {
-                    auto *sel = getWidget<ToggleButton>(fmt::format("lfo{}SelectButton", i + 1));
-                    const bool vis = (i == whichIdx) && sel && sel->getToggleState();
-
-                    for (auto *c : lfoControls[i])
-                    {
-                        if (c)
-                        {
-                            c->setVisible(vis);
-                        }
-                    }
-                }
-
-                if (auto *mlb = getWidget<ToggleButton>("midiLearnButton");
-                    mlb && mlb->getToggleState())
-                {
-                    enterMidiLearnMode();
-                }
-            };
+            tb->onClick = [this, whichIdx]() { processor.selectedLFOIndex = whichIdx; };
 
             // Trigger the initial selection once all LFO buttons have been created.
             // We do this after the loop via a deferred check on the last LFO index.
@@ -2126,18 +2230,6 @@ ObxfAudioProcessorEditor::~ObxfAudioProcessorEditor()
     multiStateAttachments.clear();
     popupMenus.clear();
     componentMap.clear();
-    globalControls.clear();
-    mpeControls.clear();
-
-    for (auto &controls : lfoControls)
-    {
-        controls.clear();
-    }
-
-    for (auto &controls : mpeMatrixControls)
-    {
-        controls.clear();
-    }
 
     juce::PopupMenu::dismissAllActiveMenus();
 }

--- a/src/PluginEditor.h
+++ b/src/PluginEditor.h
@@ -180,14 +180,32 @@ class ObxfAudioProcessorEditor final : public juce::AudioProcessorEditor,
     using KnobPostCreate = std::function<void(Knob *)>;
     using ButtonPostCreate = std::function<void(ToggleButton *)>;
 
+    struct PanelGroup;
+
+    struct Panel
+    {
+        std::string selectorButtonName;
+        std::vector<std::string> widgetNames;
+        std::unique_ptr<PanelGroup> childGroup;
+        std::vector<juce::Component *> resolvedWidgets;
+    };
+
+    struct PanelGroup
+    {
+        std::vector<Panel> panels;
+        int activePanel{0};
+
+        void resolve(const std::map<juce::String, std::unique_ptr<juce::Component>> &componentMap);
+        void showPanel(int index);
+        void hideAll();
+    };
+
     struct KnobDescriptor
     {
         std::string paramId;
         std::string displayName;
         float defaultVal{0.f};
         std::string defaultAsset{"knob"};
-        int lfoGroup{-1}; // if >= 0, added to lfoControls[lfoGroup]
-        bool isGlobalControl{false};
         KnobPostCreate postCreate;
     };
 
@@ -196,8 +214,6 @@ class ObxfAudioProcessorEditor final : public juce::AudioProcessorEditor,
         std::string paramId;
         std::string displayName;
         std::string defaultAsset{"button"};
-        int lfoGroup{-1};
-        bool isGlobalControl{false};
         ButtonPostCreate postCreate;
     };
 
@@ -207,7 +223,6 @@ class ObxfAudioProcessorEditor final : public juce::AudioProcessorEditor,
         std::string displayName;
         std::string defaultAsset{"button-dual"};
         uint8_t numStates{3};
-        int lfoGroup{-1};
     };
 
     struct ListDescriptor
@@ -215,7 +230,6 @@ class ObxfAudioProcessorEditor final : public juce::AudioProcessorEditor,
         std::string paramId;
         std::string displayName;
         std::string defaultAsset;
-        bool isGlobalControl{false};
     };
 
     // Cached per-widget layout entry, populated once from XML and reused in resized()
@@ -229,6 +243,9 @@ class ObxfAudioProcessorEditor final : public juce::AudioProcessorEditor,
     static const std::unordered_map<std::string, ButtonDescriptor> &buttonRegistry();
     static const std::unordered_map<std::string, MultiStateDescriptor> &multiStateRegistry();
     static const std::unordered_map<std::string, ListDescriptor> &listRegistry();
+    static std::map<std::string, PanelGroup> panelGroupDefinitions();
+
+    std::map<std::string, PanelGroup> panelGroups;
 
     std::unique_ptr<juce::Timer> idleTimer;
     std::unique_ptr<juce::XmlElement> cachedThemeXml;
@@ -252,13 +269,6 @@ class ObxfAudioProcessorEditor final : public juce::AudioProcessorEditor,
     std::map<juce::String, juce::Component *> componentByParamID;
 
     ScalingImageCache imageCache;
-
-    // LFO/global/MPE control groups — raw pointers into componentMap entries,
-    // used only for bulk visibility toggling. Cleared on theme reload.
-    std::array<std::vector<juce::Component *>, NUM_LFOS> lfoControls;
-    std::vector<juce::Component *> globalControls;
-    std::vector<juce::Component *> mpeControls;
-    std::array<std::vector<juce::Component *>, 4> mpeMatrixControls;
 
     Utils::ThemeLocation themeLocation;
 


### PR DESCRIPTION
Instead of stupid individual members per panel group, and lfoGroup and isGlobalControl members of the various widget descriptor structs.

Also fix incorrect asset assigned to Vibrato LFO Wave across both themes (probably a copy paste error in one of previous commits).

Also refactor how hiding and showing of the various filter controls is done - it's now delegated to onClick callbacks of the buttons rather than being polled in idle(). Cleaner!

Assisted-By: Claude Sonnet 4.6 noreply@anthropic.com