### PR TITLE
Implement OB-Xd bank import

### DIFF
--- a/src/ObxfEditor.cpp
+++ b/src/ObxfEditor.cpp
@@ -789,10 +789,15 @@ void ObxfAudioProcessorEditor::filesDropped(const juce::StringArray &files, int 
     if (files.size() > 0)
     {
         const auto file = juce::File(files[0]);
+        const juce::String ext = file.getFileExtension().toLowerCase();
 
-        if (const juce::String ext = file.getFileExtension().toLowerCase(); ext == ".fxp")
+        if (ext == ".fxp")
         {
             utils.loadPatch(file);
+        }
+        else if (ext == ".fxb")
+        {
+            importObxdBank(file);
         }
     }
 }

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -319,6 +319,46 @@ bool Utils::loadPatch(const juce::File &fxpFile, Program &program)
     return false;
 }
 
+bool Utils::serializeProgramToMemoryBlock(const Program &program, juce::MemoryBlock &out) const
+{
+    // Build the OB-Xf program XML directly from the supplied Program, mirroring
+    // the schema written by StateManager::getProgramStateInformation but without
+    // touching the active program or going through any callbacks.
+    juce::XmlElement xmlState("OB-Xf");
+    xmlState.setAttribute("ob-xf_version", humanReadableVersion(currentStreamingVersion));
+
+    for (const auto &[id, atomicVal] : program.values)
+        xmlState.setAttribute(id, static_cast<double>(atomicVal.load()));
+
+    xmlState.setAttribute("programName", program.getName());
+    xmlState.setAttribute("author", program.getAuthor());
+    xmlState.setAttribute("license", program.getLicense());
+    xmlState.setAttribute("category", program.getCategory());
+    xmlState.setAttribute("project", program.getProject());
+
+    juce::MemoryBlock xmlChunk;
+    juce::AudioProcessor::copyXmlToBinary(xmlState, xmlChunk);
+
+    const size_t totalLen = sizeof(fxProgramSet) + xmlChunk.getSize() - 8;
+    out.setSize(totalLen, true);
+
+    auto *set = static_cast<fxProgramSet *>(out.getData());
+    set->chunkMagic = fxbName("CcnK");
+    set->byteSize = 0;
+    set->fxMagic = fxbName("FPCh");
+    set->version = fxbSwap(fxbVersionNum);
+    set->fxID = fxbName("OBXf");
+    set->fxVersion = fxbSwap(fxbVersionNum);
+    set->numPrograms = fxbSwap(1);
+
+    program.getName().copyToUTF8(set->name, sizeof(set->name));
+
+    set->chunkSize = fxbSwap(static_cast<int32_t>(xmlChunk.getSize()));
+    xmlChunk.copyTo(set->chunk, 0, xmlChunk.getSize());
+
+    return true;
+}
+
 bool Utils::serializePatchAsFXPOnto(juce::MemoryBlock &memoryBlock) const
 {
     if (getProgramStateInformation)

--- a/src/Utils.h
+++ b/src/Utils.h
@@ -241,6 +241,10 @@ class Utils final
     bool savePatch(const juce::File &fxpFile);
     void initializePatch() const;
 
+    // Serialize an arbitrary Program (not necessarily the active one) into a MemoryBlock
+    // Used by the OB-Xd importer to write individual patches
+    bool serializeProgramToMemoryBlock(const Program &program, juce::MemoryBlock &out) const;
+
     // copy paste and detect a serialized FXP onto clipboard
     void copyPatch();
     void pastePatch();

--- a/src/editor/ObxfEditorMenus.cpp
+++ b/src/editor/ObxfEditorMenus.cpp
@@ -26,6 +26,8 @@
 #include "gui/FocusDebugger.h"
 #include "gui/FocusOrder.h"
 
+#include "state/ObxdImporter.h"
+
 // Menu setup
 void ObxfAudioProcessorEditor::setupPolyphonyMenu() const
 {
@@ -612,6 +614,19 @@ void ObxfAudioProcessorEditor::MenuActionCallback(int action)
 #endif
     }
 
+    if (action == MenuAction::ImportObxdBank)
+    {
+        fileChooser =
+            std::make_unique<juce::FileChooser>("Import OB-Xd Bank", juce::File(), "*.fxb", true);
+
+        fileChooser->launchAsync(
+            juce::FileBrowserComponent::openMode | juce::FileBrowserComponent::canSelectFiles,
+            [this](const juce::FileChooser &chooser) {
+                if (const juce::File result = chooser.getResult(); result != juce::File())
+                    importObxdBank(result);
+            });
+    }
+
 #if (defined(DEBUG) || defined(_DEBUG)) && !JUCE_IOS
     // Open Melatonin inspector
     if (action == MenuAction::Inspector)
@@ -642,6 +657,67 @@ void ObxfAudioProcessorEditor::keyboardFocusMainMenu()
             });
         }
     }
+}
+
+void ObxfAudioProcessorEditor::importObxdBank(const juce::File &fxbFile)
+{
+    juce::MemoryBlock fileData;
+    if (!fxbFile.loadFileAsData(fileData))
+    {
+        juce::AlertWindow::showMessageBoxAsync(juce::AlertWindow::WarningIcon, "OB-Xd Bank Import",
+                                               "Could not read the selected file!");
+        return;
+    }
+
+    if (!ObxdImporter::isOBXdData(fileData.getData(), fileData.getSize()))
+    {
+        juce::AlertWindow::showMessageBoxAsync(
+            juce::AlertWindow::WarningIcon, "OB-Xd Bank Import",
+            "The selected file does not appear to be a valid OB-Xd bank!");
+        return;
+    }
+
+    const juce::String bankName = fxbFile.getFileNameWithoutExtension();
+    const juce::File destFolder = utils.getUserPatchFolder();
+
+    const auto result = ObxdImporter::importBankFromFxb(
+        fileData.getData(), fileData.getSize(), bankName, destFolder,
+        [this](const Program &prog, juce::MemoryBlock &mb) {
+            return utils.serializeProgramToMemoryBlock(prog, mb);
+        });
+
+    if (result.parseError)
+    {
+        juce::AlertWindow::showMessageBoxAsync(
+            juce::AlertWindow::WarningIcon, "OB-Xd Bank Import",
+            "The file could not be parsed as a valid OB-Xd bank!");
+        return;
+    }
+
+    utils.rescanPatchTree();
+
+    const auto pn = processor.getActiveProgram().getName().toStdString();
+
+    processor.resetLastLoadedProgramByName(pn);
+
+    juce::String msg;
+    if (result.imported == 0)
+    {
+        msg = "No patches were imported from \"" + bankName + "\".";
+    }
+    else
+    {
+        msg = juce::String(result.imported) + " patch" + (result.imported == 1 ? "" : "es") +
+              " imported from \"" + bankName + "\".";
+    }
+
+    if (result.skipped > 0)
+    {
+        msg += "\n" + juce::String(result.skipped) + " init patch" +
+               (result.skipped == 1 ? " was" : "es were") + " skipped.";
+    }
+
+    juce::AlertWindow::showMessageBoxAsync(juce::AlertWindow::InfoIcon, "OB-Xd Bank Import", msg);
 }
 
 // Patch list
@@ -716,6 +792,11 @@ juce::PopupMenu ObxfAudioProcessorEditor::createPatchList(juce::PopupMenu &menu)
 #endif
                  true, false);
     menu.addItem(MenuAction::SavePatch, toOSCase("Save Patch..."), true, false);
+
+    menu.addSeparator();
+
+    menu.addItem(MenuAction::ImportObxdBank, toOSCase("Import ") + "OB-Xd" + toOSCase(" Bank..."),
+                 true, false);
 
     menu.addSeparator();
 

--- a/src/editor/ObxfEditorMenus.h
+++ b/src/editor/ObxfEditorMenus.h
@@ -32,6 +32,7 @@ void createMidiMapMenu(int menuNo, juce::PopupMenu &menuMidi);
 void resultFromMenu(juce::Point<int> pos);
 void MenuActionCallback(int action);
 void keyboardFocusMainMenu();
+void importObxdBank(const juce::File &fxbFile);
 
 // Patch list
 juce::PopupMenu createPatchList(juce::PopupMenu &menu) const;

--- a/src/state/ObxdImporter.cpp
+++ b/src/state/ObxdImporter.cpp
@@ -572,3 +572,65 @@ bool ObxdImporter::importSingleOnto(const void *data, size_t size, Program &outP
 
     return wrote;
 }
+
+ObxdImporter::BankImportResult ObxdImporter::importBankFromFxb(
+    const void *data, size_t size, const juce::String &bankName, const juce::File &destFolder,
+    const std::function<bool(const Program &, juce::MemoryBlock &)> &serializePatch)
+{
+    BankImportResult result;
+
+    const juce::File bankFolder = destFolder.getChildFile(bankName);
+
+    bool visitOk = visitPrograms(
+        data, size, [&](int /*idx*/, bool /*isCurrent*/, const juce::XmlElement &programEl) {
+            // Check for init patch by name before translating
+            const juce::String programName = programEl.getStringAttribute("programName", "Default");
+
+            if (programName.trim().equalsIgnoreCase("Default"))
+            {
+                ++result.skipped;
+                return;
+            }
+
+            Program prog;
+            std::vector<std::string> warnings;
+            translateProgramFromXml(programEl, prog, warnings);
+
+            // Override the project metadata with the bank name
+            prog.setProject(bankName);
+
+            juce::MemoryBlock mb;
+            if (!serializePatch(prog, mb))
+            {
+                // serialization failure — treat as a skip but don't count as skipping an init patch
+                return;
+            }
+
+            // Sanitize patch name for use as a filename.
+            juce::String safeName = prog.getName().replaceCharacters("\\/:*?\"<>|", " ").trim();
+
+            if (safeName.isEmpty())
+            {
+                safeName = juce::String("Patch ") + juce::String(result.imported + 1);
+            }
+
+            const juce::File patchFile = bankFolder.getChildFile(safeName + ".fxp");
+
+            if (!bankFolder.createDirectory())
+            {
+                return;
+            }
+
+            if (patchFile.replaceWithData(mb.getData(), mb.getSize()))
+            {
+                ++result.imported;
+            }
+        });
+
+    if (!visitOk)
+    {
+        result.parseError = true;
+    }
+
+    return result;
+}

--- a/src/state/ObxdImporter.h
+++ b/src/state/ObxdImporter.h
@@ -54,6 +54,24 @@ class ObxdImporter
     // Val_<k>/<k> attributes) onto an OB-Xf Program. Public for tests.
     static void translateProgramFromXml(const juce::XmlElement &e, Program &outProgram,
                                         std::vector<std::string> &warnings);
+
+    // Result of an FXB bank import.
+    struct BankImportResult
+    {
+        int imported{0}; // number of patches written to disk
+        int skipped{0};  // number of "Default" (init) patches skipped
+        bool parseError{false};
+    };
+
+    // Import every non-default program from an OB-Xd FXB onto disk.
+    // Each patch is written as an FXP into `destFolder/<bankName>/<patchName>.fxp`.
+    // The Project metadata field of every imported patch is set to `bankName`.
+    // Patches whose programName is "Default" are counted but skipped.
+    // `serializePatch` is a callback that turns a populated Program into an FXP
+    // MemoryBlock (mirrors the serialization already available in StateManager/Utils).
+    static BankImportResult importBankFromFxb(
+        const void *data, size_t size, const juce::String &bankName, const juce::File &destFolder,
+        const std::function<bool(const Program &, juce::MemoryBlock &)> &serializePatch);
 };
 
 #endif // OBXF_SRC_STATE_OBXDIMPORTER_H

--- a/src/utilities/KeyCommandHandler.h
+++ b/src/utilities/KeyCommandHandler.h
@@ -48,6 +48,8 @@ struct MenuAction
     static constexpr int SetDefaultPatch = 11;
     static constexpr int RefreshBrowser = 12;
 
+    static constexpr int ImportObxdBank = 13;
+
     static constexpr int Inspector = 100;
 };
 


### PR DESCRIPTION
Adds a menu item and drag&drop handler for importing OB-Xd FXBs cleanly. Skips init patches (named "Default") on import. Attaches Project metadata to saved patches based on the FXB's filename.

Closes #636!