### PR TITLE
Optimize the "scan-every-every" loop in enterMidiLearnMode()

### DIFF
--- a/src/ObxfEditor.cpp
+++ b/src/ObxfEditor.cpp
@@ -165,6 +165,8 @@ ObxfAudioProcessorEditor::ObxfAudioProcessorEditor(ObxfAudioProcessor &p)
     if (juce::PluginHostType().isBitwigStudio())
         dontParentMenusToEditor = true;
 #endif
+
+    initializeEditorCallbacks();
 }
 
 void ObxfAudioProcessorEditor::parentHierarchyChanged()
@@ -698,6 +700,7 @@ void ObxfAudioProcessorEditor::mouseUp(const juce::MouseEvent &e)
 void ObxfAudioProcessorEditor::handleAsyncUpdate()
 {
     scaleFactorChanged();
+    rebuildMidiLearnCCMap();
     repaint();
 }
 
@@ -839,9 +842,18 @@ float ObxfAudioProcessorEditor::menuScaleFactor() const
 void ObxfAudioProcessorEditor::setScaleFactor(float newScale)
 {
     if (ignoreHostScale)
+    {
         newScale = 1.f;
+    }
+
     utils.setPluginAPIScale(newScale);
+
     // this line causes the crash with bitmap assets we've been chasing
     // Why? We kinda need it I think...
     // AudioProcessorEditor::setScaleFactor(newScale);
+}
+
+void ObxfAudioProcessorEditor::initializeEditorCallbacks()
+{
+    processor.getMidiHandler().onMidiLearnBinding = [this]() { triggerAsyncUpdate(); };
 }

--- a/src/ObxfEditor.h
+++ b/src/ObxfEditor.h
@@ -154,6 +154,8 @@ class ObxfAudioProcessorEditor final : public juce::AudioProcessorEditor,
     bool ignoreHostScale{false};
     bool dontParentMenusToEditor{false};
 
+    void initializeEditorCallbacks();
+
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(ObxfAudioProcessorEditor)
 };
 

--- a/src/components/MidiLearnOverlay.h
+++ b/src/components/MidiLearnOverlay.h
@@ -64,7 +64,9 @@ class MidiLearnOverlay : public juce::Component
             if (event.position.x < midiLearnRectH)
             {
                 if (onClearCallback)
+                {
                     onClearCallback(anchorComp);
+                }
             }
         }
     }

--- a/src/editor/ObxfEditorMidiLearn.cpp
+++ b/src/editor/ObxfEditorMidiLearn.cpp
@@ -20,11 +20,9 @@
 
 void ObxfAudioProcessorEditor::enterMidiLearnMode()
 {
-    midiLearnMode = true;
+    rebuildMidiLearnCCMap();
 
     auto getCC = [this](Component *c) -> int {
-        OBLOGONCE(midiLearn, "Make this less scan-every-every");
-
         auto dcp = dynamic_cast<HasParameterWithID *>(c);
         auto isLastUsed{false};
 
@@ -33,16 +31,13 @@ void ObxfAudioProcessorEditor::enterMidiLearnMode()
             auto id = dcp->getParameterWithID()->getParameterID();
 
             if (id == midiLearnLastUsedPID)
-                isLastUsed = true;
-
-            auto &mm = processor.getMidiMap();
-
-            for (int i = 0; i < NUM_MIDI_CC; i++)
             {
-                if (mm.controllerParamID[i] == id)
-                {
-                    return isLastUsed ? -i : i;
-                }
+                isLastUsed = true;
+            }
+
+            if (const auto it = midiLearnCCByParamID.find(id); it != midiLearnCCByParamID.end())
+            {
+                return isLastUsed ? -it->second : it->second;
             }
         }
 
@@ -65,8 +60,9 @@ void ObxfAudioProcessorEditor::enterMidiLearnMode()
             repaint();
         };
 
-        overlay->onClearCallback = [this, pid](Component *comp) {
+        overlay->onClearCallback = [this, pid, ov = overlay.get()](Component *comp) {
             processor.getMidiMap().clearBindingByParamID(pid);
+            rebuildMidiLearnCCMap();
             repaint();
         };
 
@@ -80,11 +76,24 @@ void ObxfAudioProcessorEditor::enterMidiLearnMode()
 
 void ObxfAudioProcessorEditor::exitMidiLearnMode()
 {
-    midiLearnMode = false;
     midiLearnOverlays.clear();
     midiLearnLastUsedPID = "";
     processor.getMidiHandler().clearLastUsedParameter();
     repaint();
+}
+
+void ObxfAudioProcessorEditor::rebuildMidiLearnCCMap()
+{
+    midiLearnCCByParamID.clear();
+    const auto &mm = processor.getMidiMap();
+
+    for (int i = 0; i < NUM_MIDI_CC; i++)
+    {
+        if (!mm.controllerParamID[i].isEmpty())
+        {
+            midiLearnCCByParamID[mm.controllerParamID[i]] = i;
+        }
+    }
 }
 
 AnchorPosition ObxfAudioProcessorEditor::determineAnchorPosition(Component *comp,

--- a/src/editor/ObxfEditorMidiLearn.h
+++ b/src/editor/ObxfEditorMidiLearn.h
@@ -18,10 +18,11 @@
 
 void enterMidiLearnMode();
 void exitMidiLearnMode();
+void rebuildMidiLearnCCMap();
 
 AnchorPosition determineAnchorPosition(Component *comp, const juce::String &paramId);
 
 // Members
-bool midiLearnMode{false};
 juce::String midiLearnLastUsedPID;
 std::vector<std::unique_ptr<MidiLearnOverlay>> midiLearnOverlays;
+std::unordered_map<juce::String, int> midiLearnCCByParamID;

--- a/src/midi/MidiHandler.cpp
+++ b/src/midi/MidiHandler.cpp
@@ -188,6 +188,12 @@ void MidiHandler::processMidiPerSample(juce::MidiBufferIterator *iter,
                     midiControlledParamSet = true;
 
                     bindings.updateCC(lastUsedParameter, lastMovedController);
+
+                    if (onMidiLearnBinding)
+                    {
+                        auto callback = onMidiLearnBinding;
+                        juce::MessageManager::callAsync(callback);
+                    }
                 }
 
                 if (bindings.isBound(lastMovedController))
@@ -197,8 +203,12 @@ void MidiHandler::processMidiPerSample(juce::MidiBufferIterator *iter,
                     lagHandler->setTarget(lastMovedController, val);
 
                     lastMovedController = 0;
-                    lastUsedParameter = 0;
-                    midiControlledParamSet = false;
+
+                    if (!paramCoordinator.midiLearnAttachment.get())
+                    {
+                        lastUsedParameter = 0;
+                        midiControlledParamSet = false;
+                    }
                 }
             }
         }

--- a/src/midi/MidiHandler.h
+++ b/src/midi/MidiHandler.h
@@ -54,8 +54,6 @@ class MidiHandler
 
     [[nodiscard]] juce::String getCurrentMidiPath() const { return currentMidiPath; }
 
-    std::function<void(int)> handleMIDIProgramChangeCallback;
-
     int getLastUsedParameter() const { return lastUsedParameter; }
     void clearLastUsedParameter() { lastUsedParameter = 0; }
 
@@ -67,7 +65,9 @@ class MidiHandler
     void snapLags();
     void processLags();
 
+    std::function<void(int)> handleMIDIProgramChangeCallback;
     std::function<void(const juce::MidiMessage &)> onMidiMessageCallback;
+    std::function<void()> onMidiLearnBinding;
 
   private:
     SynthEngine &synth;


### PR DESCRIPTION
This required a cache of MIDI CC values so that we don't need to iterate over all 128 CCs for every MIDI learnable widget we have.

This then broke how MIDI learn overlays behaved on user interaction, so the cache required updating in several places, and using the async messaging to trigger the UI update on the editor. Now behavior is unchanged to how it used to be.

I have also removed the midiLearnMode member variable, because it was actually completely unused.

Assisted-By: Claude Sonnet 4.6 noreply@anthropic.com