### PR TITLE
Fix undo history spam in Live

### DIFF
--- a/src/ObxfProcessor.cpp
+++ b/src/ObxfProcessor.cpp
@@ -286,7 +286,9 @@ void ObxfAudioProcessor::applyActiveProgramValuesToJUCEParameters()
     }
 
     paramCoordinator->getParameterUpdateHandler().setSuppressGestureToUndo(true);
+
     const Program &prog = activeProgram;
+
     for (auto *param : ObxfParams(*this))
     {
         if (param)
@@ -297,14 +299,18 @@ void ObxfAudioProcessor::applyActiveProgramValuesToJUCEParameters()
                 (it != prog.values.end()) ? it->second.load() : param->meta.defaultVal;
 
             auto v = param->convertTo0to1(param->get());
+
             if (v != value)
             {
-                param->beginChangeGesture();
                 param->setValueNotifyingHost(value);
-                param->endChangeGesture();
+                param->sendValueChangedMessageToListeners(value);
             }
         }
     }
+
+    updateHostDisplay(
+        juce::AudioProcessor::ChangeDetails().withProgramChanged(true).withNonParameterStateChanged(
+            true));
 
     paramCoordinator->getParameterUpdateHandler().setSuppressGestureToUndo(false);
 }


### PR DESCRIPTION
Basically when doing applyActiveProgramValuesToJUCEParameters(), don't wrap each parameter change in a begin/end block, instead update listeners and then do updateHostDisplay() after the loop.

Fixes #642

Note that there is a really weird "Change "Volume"" undo entry that shows up in Live ONLY on second patch change after instantiation of OB-Xf. It's always that same parameter and always only after second patch change. That definitely sounds like a Live issue.