### PR TITLE
Resolve SaveDialog crashes and stale state after theme reload

### DIFF
--- a/src/ObxfEditor.cpp
+++ b/src/ObxfEditor.cpp
@@ -188,6 +188,7 @@ void ObxfAudioProcessorEditor::parentHierarchyChanged()
 void ObxfAudioProcessorEditor::resized()
 {
     scaleFactorChanged();
+
     themeLocation = utils.getCurrentThemeLocation();
 
     if (cachedLayout.empty())
@@ -196,11 +197,6 @@ void ObxfAudioProcessorEditor::resized()
     }
 
     static FocusOrder focusOrder;
-
-    if (saveDialog)
-    {
-        saveDialog->resetState();
-    }
 
     for (const auto &layout : cachedLayout)
     {
@@ -279,11 +275,6 @@ void ObxfAudioProcessorEditor::resized()
         }
     }
 
-    if (saveDialog)
-    {
-        saveDialog->resized();
-    }
-
     const float sf = impliedScaleFactor();
 
     for (auto &overlay : midiLearnOverlays)
@@ -302,6 +293,7 @@ void ObxfAudioProcessorEditor::resized()
     if (saveDialog)
     {
         saveDialog->setBounds(getBounds());
+        saveDialog->resized();
     }
 
     /*     if (mpeMatrixEditor)
@@ -660,6 +652,12 @@ void ObxfAudioProcessorEditor::scaleFactorChanged()
         backgroundIsSVG = false;
         backgroundImage = imageCache.getImageFor("background", getWidth(), getHeight());
     }
+
+    if (saveDialog)
+    {
+        saveDialog->scaleFactorChanged();
+    }
+
     repaint();
 }
 

--- a/src/components/ScalingImageCache.cpp
+++ b/src/components/ScalingImageCache.cpp
@@ -66,7 +66,17 @@ juce::Image ScalingImageCache::initializeImage(const std::string &label)
         return {};
 
     if (cachePaths.find(label) != cachePaths.end())
-        return {};
+    {
+        // cachePaths exists but svgLayers might not if a previous call
+        // populated paths but was interrupted before svg loading
+        if (svgLayers.find(label) == svgLayers.end())
+        {
+            // don't early-exit, fall through to re-populate svgLayers
+            cachePaths.erase(label);
+        }
+        else
+            return {};
+    }
 
     if (embeddedMode)
     {
@@ -281,5 +291,6 @@ int ScalingImageCache::getSvgLayerCount(const std::string &label)
 std::unique_ptr<juce::Drawable> &ScalingImageCache::getSVGDrawable(const std::string &label,
                                                                    int layer)
 {
+    initializeImage(label);
     return svgLayers[label][layer];
 }

--- a/src/editor/ObxfEditorMenus.cpp
+++ b/src/editor/ObxfEditorMenus.cpp
@@ -255,7 +255,10 @@ void ObxfAudioProcessorEditor::createMenu()
             if (theme.locationType != ll && theme.locationType == Utils::LocationType::USER)
             {
                 if (i != 0)
+                {
                     themeMenu.addSeparator();
+                }
+
                 themeMenu.addSectionHeader("User");
             }
 

--- a/src/gui/SaveDialog.h
+++ b/src/gui/SaveDialog.h
@@ -84,12 +84,7 @@ struct SaveDialog : juce::Component
 
     void resetState()
     {
-        hasSkinImage = false;
-
-        if (editor.imageCache.hasImageFor("label-bg-save-patch"))
-        {
-            hasSkinImage = true;
-        }
+        hasSkinImage = editor.imageCache.hasImageFor("label-bg-save-patch");
 
         boundsMap.clear();
         colorMap.clear();
@@ -165,8 +160,17 @@ struct SaveDialog : juce::Component
         setVisible(false);
     }
 
+    void scaleFactorChanged()
+    {
+        ok->scaleFactorChanged();
+        cancel->scaleFactorChanged();
+        category->scaleFactorChanged();
+    }
+
     void resized() override
     {
+        scaleFactorChanged();
+
         auto sc = editor.impliedScaleFactor();
         auto bx = getContentArea();
 
@@ -218,7 +222,7 @@ struct SaveDialog : juce::Component
         {
             if (editor.imageCache.isSVG("label-bg-save-patch"))
             {
-                auto &svg = editor.imageCache.getSVGDrawable("label-bg-save-patch", 0);
+                auto &svg = editor.imageCache.getSVGDrawable("label-bg-save-patch");
                 auto at = juce::AffineTransform().scaled(sc).translated(r.getX(), r.getY());
                 svg->draw(g, 1.0, at);
             }
@@ -334,7 +338,7 @@ struct SaveDialog : juce::Component
 
     std::unique_ptr<ToggleButton> ok, cancel;
     std::unique_ptr<Display> name, author, license, project;
-    std::unique_ptr<juce::ComboBox> category;
+    std::unique_ptr<ButtonList> category;
 };
 
 #endif // OB_XF_SAVEDIALOG_H


### PR DESCRIPTION
ScalingImageCache::getSVGDrawable() now calls initializeImage() before accessing svgLayers, making it consistent with all other public cache methods and preventing assert failures when the cache has been cleared by a theme change.

initializeImage() early-exit now checks for svgLayers consistency with cachePaths, self-healing any state where paths were populated but SVG drawables were not, preventing silent out-of-bounds access on the next getSVGDrawable call.

SaveDialog::resetState() was being called from resized() in ObxfEditor, wiping boundsMap and colorMap that had just been populated by createComponentsFromXml(), causing text fields to always render in the fallback red color. The resetState() call has been removed from resized().

SaveDialog now exposes scaleFactorChanged() to propagate theme/scale updates to its child widgets (ok, cancel, category), which were previously never re-evaluated after a theme switch since SaveDialog is constructed once and reused.

Assisted-By: Claude Sonnet 4.6 <noreply@anthropic.com>