### PR TITLE
Pin latest CJE, param group root gets no separator

### DIFF
--- a/src/parameter/ParameterUpdateHandler.cpp
+++ b/src/parameter/ParameterUpdateHandler.cpp
@@ -26,7 +26,7 @@ ParameterUpdateHandler::ParameterUpdateHandler(ObxfAudioProcessor &audioProcesso
 {
     std::unordered_map<std::string, juce::AudioProcessorParameterGroup *> groupPtrs;
 
-    auto root = std::make_unique<juce::AudioProcessorParameterGroup>("", "", "|");
+    auto root = std::make_unique<juce::AudioProcessorParameterGroup>("", "", "");
 
     for (const auto &info : parameters)
     {


### PR DESCRIPTION
This reinstates parameter groups for CLAP and restores parity with how VST3 and AU param groups are displayed!